### PR TITLE
Small tweaks I noticed while writing the content

### DIFF
--- a/samples/client-sdk/connectivity-tests/src/index.js
+++ b/samples/client-sdk/connectivity-tests/src/index.js
@@ -22,7 +22,7 @@ window.addEventListener('DOMContentLoaded', () => {
     setupLeaveBtn(() => {
       leave(callObject);
     });
-    runTests(callObject);
+    startTests(callObject);
   });
 });
 
@@ -48,13 +48,14 @@ function setupCallObject() {
       const p = e.participant;
       if (!p.local) return;
 
+      // Create a participant element
       const newTrack = e.track;
-
       addParticipantEle(p, participantParentEle);
       updateMediaTrack(p.session_id, newTrack);
-      enableControls(callObject);
+
+      // If this is a video track, run all tests.
       if (e.type === 'video') {
-        doAllTests(callObject, newTrack);
+        runAllTests(callObject, newTrack);
       }
     })
     .on('error', (e) => {
@@ -68,11 +69,11 @@ function setupCallObject() {
 }
 
 /**
- * Runs Daily's connection test methods and presents the results.
+ * Starts Daily's connection test methods and presents the results.
  * @param {DailyCall} callObject
  * @returns
  */
-function runTests(callObject) {
+function startTests(callObject) {
   disableTestBtn();
 
   // Reset results, in case this is a re-run.
@@ -83,7 +84,7 @@ function runTests(callObject) {
   const localParticipant = callObject.participants().local;
   const videoTrack = localParticipant?.tracks?.video?.persistentTrack;
   if (videoTrack) {
-    doAllTests(callObject, videoTrack);
+    runAllTests(callObject, videoTrack);
     return;
   }
 
@@ -102,7 +103,7 @@ function runTests(callObject) {
  * @param {DailyCall} callObject
  * @param {MediaStreamTrack} videoTrack
  */
-function doAllTests(callObject, videoTrack) {
+function runAllTests(callObject, videoTrack) {
   Promise.all([
     testConnectionQuality(callObject, videoTrack),
     testNetworkConnectivity(callObject, videoTrack),

--- a/samples/client-sdk/connectivity-tests/src/index.js
+++ b/samples/client-sdk/connectivity-tests/src/index.js
@@ -213,6 +213,9 @@ function testWebSocketConnectivity(callObject) {
         case 'passed':
           resultMsg = 'You are able to connect to WebSockets in all regions.';
           break;
+        case 'aborted':
+          resultMsg = 'The WebSocket connectivity test was aborted.';
+          break;
         default:
           resultMsg = `Unexpected network connectivity test result: ${JSON.stringify(
             testResult


### PR DESCRIPTION
This PR removes an unneeded duplicate call to enabling controls and also renames a couple of functions: one function _starts_ the tests (turning on the participant's camera if needed), and the other actually _runs_ all the tests once the camera is confirmed on and we have a video track.


It also adds a case for an `"aborted"` status in one of the tests.