### PR TITLE
Update basic demo to use participant-* events

### DIFF
--- a/samples/client-sdk/getting-started-daily-js/index.html
+++ b/samples/client-sdk/getting-started-daily-js/index.html
@@ -28,7 +28,7 @@
 
     <div class="controls">
       <button id="join-btn">Join Room</button>
-      <button id="leave-btn">Leave</button>
+      <button id="leave-btn" disabled>Leave</button>
     </div>
 
     <div class="controls">

--- a/samples/client-sdk/getting-started-daily-js/index.js
+++ b/samples/client-sdk/getting-started-daily-js/index.js
@@ -7,8 +7,6 @@
 class DailyCallManager {
   constructor() {
     this.call = Daily.createCallObject();
-    this.isCameraMuted = null;
-    this.isMicMuted = null;
     this.currentRoomUrl = null;
     this.initialize();
   }
@@ -17,7 +15,7 @@ class DailyCallManager {
    * Performs initial setup of event listeners and UI component interactions.
    */
   async initialize() {
-    await this.setupEventListeners();
+    this.setupEventListeners();
     document
       .getElementById('toggle-camera')
       .addEventListener('click', () => this.toggleCamera());
@@ -29,20 +27,16 @@ class DailyCallManager {
   /**
    * Configures event listeners for various call-related events.
    */
-  async setupEventListeners() {
+  setupEventListeners() {
     const events = {
       'active-speaker-change': this.handleActiveSpeakerChange.bind(this),
       error: this.handleError.bind(this),
       'joined-meeting': this.handleJoin.bind(this),
       'left-meeting': this.handleLeave.bind(this),
+      'participant-joined': this.handleParticipantJoinedOrUpdated.bind(this),
       'participant-left': this.handleParticipantLeft.bind(this),
+      'participant-updated': this.handleParticipantJoinedOrUpdated.bind(this),
     };
-
-    const participantEvents = ['participant-joined', 'participant-updated'];
-
-    participantEvents.forEach((event) => {
-      events[event] = this.handleParticipantJoinedOrUpdated.bind(this);
-    });
 
     Object.entries(events).forEach(([event, handler]) => {
       this.call.on(event, handler);
@@ -52,9 +46,9 @@ class DailyCallManager {
   /**
    * Handler for the local participant joining:
    * - Prints the room URL
-   * - Enables the toggle camera and mic buttons
+   * - Enables the toggle camera, toggle mic, and leave buttons
    * - Gets the initial track states
-   * - Sets up the device selectors
+   * - Sets up and enables the device selectors
    * @param {Object} event - The joined-meeting event object.
    */
   handleJoin(event) {
@@ -62,9 +56,11 @@ class DailyCallManager {
 
     console.log(`Successfully joined: ${this.currentRoomUrl}`);
 
-    // Update the join and leave button states
+    // Update the participant count
+    this.updateAndDisplayParticipantCount();
+
+    // Enable the leave button
     document.getElementById('leave-btn').disabled = false;
-    document.getElementById('join-btn').disabled = true;
 
     // Enable the toggle camera and mic buttons and selectors
     document.getElementById('toggle-camera').disabled = false;
@@ -75,13 +71,9 @@ class DailyCallManager {
     // Set up the camera and mic selectors
     this.setupDeviceSelectors();
 
-    // Initialize the camera and microphone states and UI for the local participant
+    // Initialize the camera and microphone states and UI for the local
+    // participant
     Object.entries(tracks).forEach(([trackType, trackInfo]) => {
-      if (trackType === 'video') {
-        this.isCameraMuted = trackInfo.state !== 'playable';
-      } else if (trackType === 'audio') {
-        this.isMicMuted = trackInfo.state !== 'playable';
-      }
       this.updateUiForDevicesState(trackType, trackInfo);
     });
   }
@@ -131,14 +123,14 @@ class DailyCallManager {
   }
 
   /**
-   * Handles errors emitted from the Daily call object.
+   * Handles fatal errors emitted from the Daily call object.
+   * These errors result in the participant leaving the meeting. A
+   * `left-meeting` event will also be sent, so we still rely on that event
+   * for cleanup.
    * @param {Object} e - The error event object.
    */
   handleError(e) {
-    console.error('DAILY SENT AN ERROR!', e);
-    if (e.error?.details?.sourceError) {
-      console.log('Original Error', e.error?.details?.sourceError);
-    }
+    console.error('DAILY SENT AN ERROR!', e.error ? e.error : e.errorMsg);
   }
 
   /**
@@ -155,6 +147,9 @@ class DailyCallManager {
 
     // Now, remove the related video UI
     document.getElementById(`video-container-${participantId}`)?.remove();
+
+    // Update the participant count
+    this.updateAndDisplayParticipantCount();
   }
 
   /**
@@ -205,7 +200,8 @@ class DailyCallManager {
         this.updateVideoUi(trackInfo, participantId);
       }
 
-      // Update the camera and microphone states for the local user based on the track's state
+      // Update the camera and microphone states for the local user based on
+      // the track's state
       if (isLocal) {
         this.updateUiForDevicesState(trackType, trackInfo);
       }
@@ -244,6 +240,9 @@ class DailyCallManager {
     }
 
     try {
+      // Disable the join button to prevent multiple attempts to join
+      document.getElementById('join-btn').disabled = true;
+      // Join the room
       await this.call.join(joinOptions);
     } catch (e) {
       console.error('Join failed:', e);
@@ -251,9 +250,10 @@ class DailyCallManager {
   }
 
   /**
-   * Creates and sets up a new video container for a specific participant. This function dynamically
-   * generates a video element along with a container and an overlay displaying the participant's ID.
-   * The newly created elements are appended to a designated parent in the DOM, preparing them for video
+   * Creates and sets up a new video container for a specific participant. This
+   * function dynamically generates a video element along with a container and
+   * an overlay displaying the participant's ID. The newly created elements are
+   * appended to a designated parent in the DOM, preparing them for video
    * streaming or playback related to the specified participant.
    *
    * @param {string} participantId - The unique identifier for the participant.
@@ -278,9 +278,10 @@ class DailyCallManager {
   }
 
   /**
-   * Creates an audio element for a particular participant. This function is responsible for dynamically
-   * generating a standalone audio element that can be used to play audio streams associated with the
-   * specified participant. The audio element is appended directly to the document body or a relevant
+   * Creates an audio element for a particular participant. This function is
+   * responsible for dynamically generating a standalone audio element that can
+   * be used to play audio streams associated with the specified participant.
+   * The audio element is appended directly to the document body or a relevant
    * container, thereby preparing it for playback of the participant's audio.
    *
    * @param {string} participantId - A unique identifier corresponding to the participant.
@@ -293,16 +294,19 @@ class DailyCallManager {
   }
 
   /**
-   * Updates the media track (audio or video) source for a specific participant and plays
-   * the updated track. It checks if the source track needs to be updated and performs the
-   * update if necessary, ensuring playback of the media track.
+   * Updates the media track (audio or video) source for a specific participant
+   * and plays the updated track. It checks if the source track needs to be
+   * updated and performs the update if necessary, ensuring playback of the
+   * media track.
    *
-   * @param {string} trackType - Specifies the type of track to update ('audio' or 'video'),
-   * allowing the function to dynamically adapt to the track being processed.
-   * @param {Object} track - Contains the media track data, including the `persistentTrack`
-   * property which holds the actual MediaStreamTrack to be played or updated.
-   * @param {string} participantId - Identifies the participant whose media track is being
-   * updated.
+   * @param {string} trackType - Specifies the type of track to update ('audio'
+   * or 'video'), allowing the function to dynamically adapt to the track being
+   * processed.
+   * @param {Object} track - Contains the media track data, including the
+   * `persistentTrack` property which holds the actual MediaStreamTrack to be
+   * played or updated.
+   * @param {string} participantId - Identifies the participant whose media
+   * track is being updated.
    */
   startOrUpdateTrack(trackType, track, participantId) {
     // Construct the selector string or ID based on the trackType.
@@ -325,19 +329,22 @@ class DailyCallManager {
       return;
     }
 
-    // Check for the need to update the media source. This is determined by checking whether the
-    // existing srcObject's tracks include the new persistentTrack. If there are no existing tracks
-    // or the new track is not among them, an update is necessary.
+    // Check for the need to update the media source. This is determined by
+    // checking whether the existing srcObject's tracks include the new
+    // persistentTrack. If there are no existing tracks or the new track is not
+    // among them, an update is necessary.
     const existingTracks = trackEl.srcObject?.getTracks();
     const needsUpdate = !existingTracks?.includes(track.persistentTrack);
 
-    // Perform the media source update if needed by setting the srcObject of the target element
-    // to a new MediaStream containing the provided persistentTrack.
-    if (needsUpdate || !existingTracks) {
+    // Perform the media source update if needed by setting the srcObject of
+    // the target element to a new MediaStream containing the provided
+    // persistentTrack.
+    if (needsUpdate) {
       trackEl.srcObject = new MediaStream([track.persistentTrack]);
 
-      // Once the media metadata is loaded, attempts to play the track. Error handling for play
-      // failures is included to catch and log issues such as autoplay policies blocking playback.
+      // Once the media metadata is loaded, attempts to play the track. Error
+      // handling for play failures is included to catch and log issues such as
+      // autoplay policies blocking playback.
       trackEl.onloadedmetadata = () => {
         trackEl
           .play()
@@ -363,14 +370,12 @@ class DailyCallManager {
       .querySelector('video.video-element');
 
     switch (track.state) {
-      case 'playable':
-        videoEl.style.display = '';
-        break;
       case 'off':
       case 'interrupted':
       case 'blocked':
         videoEl.style.display = 'none'; // Hide video but keep container
         break;
+      case 'playable':
       default:
         // Here we handle all other states the same as we handle 'playable'.
         // In your code, you may choose to handle them differently.
@@ -380,11 +385,12 @@ class DailyCallManager {
   }
 
   /**
-   * Cleans up specified media track types (e.g., 'video', 'audio') for a given participant
-   * by stopping the tracks and removing their corresponding elements from the DOM. This is
-   * essential for properly managing resources when participants leave or change their track
-   * states.
-   * @param {Array} trackTypes - An array of track types to destroy, e.g., ['video', 'audio'].
+   * Cleans up specified media track types (e.g., 'video', 'audio') for a given
+   * participant by stopping the tracks and removing their corresponding
+   * elements from the DOM. This is essential for properly managing resources
+   * when participants leave or change their track states.
+   * @param {Array} trackTypes - An array of track types to destroy, e.g.,
+   * ['video', 'audio'].
    * @param {string} participantId - The ID of the participant.
    */
   destroyTracks(trackTypes, participantId) {
@@ -393,7 +399,7 @@ class DailyCallManager {
       const element = document.getElementById(elementId);
       if (element) {
         element.srcObject = null; // Release media resources
-        element.parentNode.removeChild(element); // Remove the element from the DOM
+        element.parentNode.removeChild(element); // Remove element from the DOM
       }
     });
   }
@@ -402,45 +408,46 @@ class DailyCallManager {
    * Toggles the local video track's mute state.
    */
   toggleCamera() {
-    this.call.setLocalVideo(this.isCameraMuted);
-    this.isCameraMuted = !this.isCameraMuted;
+    this.call.setLocalVideo(!this.call.localVideo());
   }
 
   /**
    * Toggles the local audio track's mute state.
    */
   toggleMicrophone() {
-    this.call.setLocalAudio(this.isMicMuted);
-    this.isMicMuted = !this.isMicMuted;
+    this.call.setLocalAudio(!this.call.localAudio());
   }
 
   /**
-   * Updates the UI to reflect the current states of the local participant's camera and microphone.
-   * @param {string} trackType - The type of track, either 'video' for cameras or 'audio' for microphones.
+   * Updates the UI to reflect the current states of the local participant's
+   * camera and microphone.
+   * @param {string} trackType - The type of track, either 'video' for cameras
+   * or 'audio' for microphones.
    * @param {Object} trackInfo - The track object.
    */
   updateUiForDevicesState(trackType, trackInfo) {
     // For video, set the camera state
     if (trackType === 'video') {
       document.getElementById('camera-state').textContent = `Camera: ${
-        trackInfo.state === 'playable' ? 'On' : 'Off'
+        this.call.localVideo() ? 'On' : 'Off'
       }`;
     } else if (trackType === 'audio') {
       // For audio, set the mic state
       document.getElementById('mic-state').textContent = `Mic: ${
-        trackInfo.state === 'playable' ? 'On' : 'Off'
+        this.call.localAudio() ? 'On' : 'Off'
       }`;
     }
   }
 
   /**
-   * Sets up device selectors for cameras and microphones by dynamically populating them
-   * with available devices and attaching event listeners to handle device selection changes.
+   * Sets up device selectors for cameras and microphones by dynamically
+   * populating them with available devices and attaching event listeners to
+   * handle device selection changes.
    */
   async setupDeviceSelectors() {
     // Fetch current input devices settings and an array of available devices.
     const selectedDevices = await this.call.getInputDevices();
-    const { devices } = await this.call.enumerateDevices();
+    const { devices: allDevices } = await this.call.enumerateDevices();
 
     // Element references for camera and microphone selectors.
     const selectors = {
@@ -448,7 +455,8 @@ class DailyCallManager {
       audioinput: document.getElementById('mic-selector'),
     };
 
-    // Prepare selectors by clearing existing options and adding a non-selectable prompt.
+    // Prepare selectors by clearing existing options and adding a
+    // non-selectable prompt.
     Object.values(selectors).forEach((selector) => {
       selector.innerHTML = '';
       const promptOption = new Option(
@@ -462,7 +470,7 @@ class DailyCallManager {
     });
 
     // Create and append options to the selectors based on available devices.
-    devices.forEach((device) => {
+    allDevices.forEach((device) => {
       if (device.label && selectors[device.kind]) {
         const isSelected =
           selectedDevices[device.kind === 'videoinput' ? 'camera' : 'mic']
@@ -477,7 +485,7 @@ class DailyCallManager {
       }
     });
 
-    //Attach event listeners for device changes.
+    // Listen for user device change requests.
     Object.entries(selectors).forEach(([deviceKind, selector]) => {
       selector.addEventListener('change', async (e) => {
         const deviceId = e.target.value;
@@ -495,14 +503,17 @@ class DailyCallManager {
    * This method combines getting the participant count and updating the UI.
    */
   updateAndDisplayParticipantCount() {
-    const participantCount = Object.keys(this.call.participants()).length;
+    const participantCount =
+      this.call.participantCounts().present +
+      this.call.participantCounts().hidden;
     document.getElementById(
       'participant-count'
     ).textContent = `Participants: ${participantCount}`;
   }
 
   /**
-   * Leaves the call and performs necessary cleanup operations like removing video elements.
+   * Leaves the call and performs necessary cleanup operations like removing
+   * video elements.
    */
   async leave() {
     try {
@@ -518,7 +529,8 @@ class DailyCallManager {
 }
 
 /**
- * Main entry point: Setup and event listener bindings after the DOM is fully loaded.
+ * Main entry point: Setup and event listener bindings after the DOM is fully
+ * loaded.
  */
 document.addEventListener('DOMContentLoaded', async () => {
   const dailyCallManager = new DailyCallManager();


### PR DESCRIPTION
Following Paul's advice and using the `participant-*` events to drive this track changes in this app. I also found some areas to consolidate and clean up. Some were caused by this change and others were just not needed. Hopefully this is cleaner and matches the pattern we want developers to follow.