### PR TITLE
Add support for custom audio and video tracks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,25 +1,19 @@
 {
   "env": {
-      "browser": true,
-      "es2021": true
+    "browser": true,
+    "es2021": true
   },
-  "extends": [
-      "airbnb-base",
-      "prettier"
-  ],
+  "extends": ["airbnb-base", "prettier"],
   "plugins": ["prettier"],
   "parserOptions": {
-      "ecmaVersion": "latest",
-      "sourceType": "module"
+    "ecmaVersion": "latest",
+    "sourceType": "module"
   },
   "rules": {
-      "prettier/prettier": ["error", { "singleQuote": true }],
-      "no-continue": "off",
-      "no-use-before-define": [
-          "error",
-          { "functions": false }
-      ],
-      "import/extensions": "off"
-
+    "prettier/prettier": ["error", { "singleQuote": true }],
+    "no-continue": "off",
+    "no-console": "off",
+    "no-use-before-define": ["error", { "functions": false }],
+    "import/extensions": "off"
   }
 }

--- a/samples/client-sdk/getting-started-daily-js/index.js
+++ b/samples/client-sdk/getting-started-daily-js/index.js
@@ -20,11 +20,11 @@ class DailyCallManager {
   async initialize() {
     this.setupEventListeners();
     document
-      .getElementById("toggle-camera")
-      .addEventListener("click", () => this.toggleCamera());
+      .getElementById('toggle-camera')
+      .addEventListener('click', () => this.toggleCamera());
     document
-      .getElementById("toggle-mic")
-      .addEventListener("click", () => this.toggleMicrophone());
+      .getElementById('toggle-mic')
+      .addEventListener('click', () => this.toggleMicrophone());
   }
 
   /**
@@ -32,13 +32,13 @@ class DailyCallManager {
    */
   setupEventListeners() {
     const events = {
-      "active-speaker-change": this.handleActiveSpeakerChange.bind(this),
+      'active-speaker-change': this.handleActiveSpeakerChange.bind(this),
       error: this.handleError.bind(this),
-      "joined-meeting": this.handleJoin.bind(this),
-      "left-meeting": this.handleLeave.bind(this),
-      "participant-joined": this.handleParticipantJoinedOrUpdated.bind(this),
-      "participant-left": this.handleParticipantLeft.bind(this),
-      "participant-updated": this.handleParticipantJoinedOrUpdated.bind(this),
+      'joined-meeting': this.handleJoin.bind(this),
+      'left-meeting': this.handleLeave.bind(this),
+      'participant-joined': this.handleParticipantJoinedOrUpdated.bind(this),
+      'participant-left': this.handleParticipantLeft.bind(this),
+      'participant-updated': this.handleParticipantJoinedOrUpdated.bind(this),
     };
 
     Object.entries(events).forEach(([event, handler]) => {
@@ -63,13 +63,13 @@ class DailyCallManager {
     this.updateAndDisplayParticipantCount();
 
     // Enable the leave button
-    document.getElementById("leave-btn").disabled = false;
+    document.getElementById('leave-btn').disabled = false;
 
     // Enable the toggle camera and mic buttons and selectors
-    document.getElementById("toggle-camera").disabled = false;
-    document.getElementById("toggle-mic").disabled = false;
-    document.getElementById("camera-selector").disabled = false;
-    document.getElementById("mic-selector").disabled = false;
+    document.getElementById('toggle-camera').disabled = false;
+    document.getElementById('toggle-mic').disabled = false;
+    document.getElementById('camera-selector').disabled = false;
+    document.getElementById('mic-selector').disabled = false;
 
     // Set up the camera and mic selectors
     this.setupDeviceSelectors();
@@ -90,36 +90,36 @@ class DailyCallManager {
    * - Removes all video containers
    */
   handleLeave() {
-    console.log("Successfully left the call");
+    console.log('Successfully left the call');
 
     // Update the join and leave button states
-    document.getElementById("leave-btn").disabled = true;
-    document.getElementById("join-btn").disabled = false;
+    document.getElementById('leave-btn').disabled = true;
+    document.getElementById('join-btn').disabled = false;
 
     // Disable the toggle camera and mic buttons
-    document.getElementById("toggle-camera").disabled = true;
-    document.getElementById("toggle-mic").disabled = true;
+    document.getElementById('toggle-camera').disabled = true;
+    document.getElementById('toggle-mic').disabled = true;
 
     // Reset and disable the camera and mic selectors
-    const cameraSelector = document.getElementById("camera-selector");
-    const micSelector = document.getElementById("mic-selector");
+    const cameraSelector = document.getElementById('camera-selector');
+    const micSelector = document.getElementById('mic-selector');
     cameraSelector.selectedIndex = 0;
     micSelector.selectedIndex = 0;
     cameraSelector.disabled = true;
     micSelector.disabled = true;
 
     // Update the call state in the UI
-    document.getElementById("camera-state").textContent = "Camera: Off";
-    document.getElementById("mic-state").textContent = "Mic: Off";
+    document.getElementById('camera-state').textContent = 'Camera: Off';
+    document.getElementById('mic-state').textContent = 'Mic: Off';
     document.getElementById(
-      "participant-count"
+      'participant-count'
     ).textContent = `Participants: 0`;
     document.getElementById(
-      "active-speaker"
+      'active-speaker'
     ).textContent = `Active Speaker: None`;
 
     // Remove all video containers
-    const videosDiv = document.getElementById("videos");
+    const videosDiv = document.getElementById('videos');
     while (videosDiv.firstChild) {
       videosDiv.removeChild(videosDiv.firstChild);
     }
@@ -133,7 +133,7 @@ class DailyCallManager {
    * @param {Object} e - The error event object.
    */
   handleError(e) {
-    console.error("DAILY SENT AN ERROR!", e.error ? e.error : e.errorMsg);
+    console.error('DAILY SENT AN ERROR!', e.error ? e.error : e.errorMsg);
   }
 
   /**
@@ -149,8 +149,8 @@ class DailyCallManager {
     // When a participant leaves, we don't have trackInfo, but we know these are regular tracks
     this.destroyTracks(
       [
-        { trackType: "video", trackInfo: null },
-        { trackType: "audio", trackInfo: null },
+        { trackType: 'video', trackInfo: null },
+        { trackType: 'audio', trackInfo: null },
       ],
       participantId
     );
@@ -202,7 +202,7 @@ class DailyCallManager {
         const isCustomTrack = trackInfo.kind;
 
         // For custom audio tracks, create a dedicated audio element if it doesn't exist
-        if (isCustomTrack && trackInfo.kind === "audio" && !isLocal) {
+        if (isCustomTrack && trackInfo.kind === 'audio' && !isLocal) {
           const customAudioId = `${trackType}-${participantId}`;
           if (!document.getElementById(customAudioId)) {
             this.createCustomAudioElement(trackType, participantId);
@@ -210,7 +210,7 @@ class DailyCallManager {
         }
 
         // For custom video tracks, create a dedicated video container if it doesn't exist
-        if (isCustomTrack && trackInfo.kind === "video") {
+        if (isCustomTrack && trackInfo.kind === 'video') {
           const customVideoId = `video-container-${trackType}-${participantId}`;
           if (!document.getElementById(customVideoId)) {
             this.createCustomVideoContainer(trackType, participantId);
@@ -220,7 +220,7 @@ class DailyCallManager {
         // Check if this is the local participant's audio track.
         // If so, we will skip playing it, as it's already being played.
         // We'll start or update tracks in all other cases.
-        if (!(isLocal && trackType === "audio")) {
+        if (!(isLocal && trackType === 'audio')) {
           this.startOrUpdateTrack(trackType, trackInfo, participantId);
         }
       } else {
@@ -230,7 +230,7 @@ class DailyCallManager {
 
       // Update the video UI based on the track's state
       // For regular and custom video tracks
-      if (trackType === "video" || trackInfo.kind === "video") {
+      if (trackType === 'video' || trackInfo.kind === 'video') {
         this.updateVideoUi(trackInfo, participantId, trackType);
       }
 
@@ -248,7 +248,7 @@ class DailyCallManager {
    */
   handleActiveSpeakerChange(event) {
     document.getElementById(
-      "active-speaker"
+      'active-speaker'
     ).textContent = `Active Speaker: ${event.activeSpeaker.peerId}`;
   }
 
@@ -259,7 +259,7 @@ class DailyCallManager {
    */
   async joinRoom(roomUrl, joinToken = null) {
     if (!roomUrl) {
-      console.error("Room URL is required to join a room.");
+      console.error('Room URL is required to join a room.');
       return;
     }
 
@@ -268,18 +268,18 @@ class DailyCallManager {
     const joinOptions = { url: roomUrl };
     if (joinToken) {
       joinOptions.token = joinToken;
-      console.log("Joining with a token.");
+      console.log('Joining with a token.');
     } else {
-      console.log("Joining without a token.");
+      console.log('Joining without a token.');
     }
 
     try {
       // Disable the join button to prevent multiple attempts to join
-      document.getElementById("join-btn").disabled = true;
+      document.getElementById('join-btn').disabled = true;
       // Join the room
       await this.call.join(joinOptions);
     } catch (e) {
-      console.error("Join failed:", e);
+      console.error('Join failed:', e);
     }
   }
 
@@ -294,20 +294,20 @@ class DailyCallManager {
    */
   createVideoContainer(participantId) {
     // Create a video container for the participant
-    const videoContainer = document.createElement("div");
+    const videoContainer = document.createElement('div');
     videoContainer.id = `video-container-${participantId}`;
-    videoContainer.className = "video-container";
-    document.getElementById("videos").appendChild(videoContainer);
+    videoContainer.className = 'video-container';
+    document.getElementById('videos').appendChild(videoContainer);
 
     // Add an overlay to display the participant's session ID
-    const sessionIdOverlay = document.createElement("div");
-    sessionIdOverlay.className = "session-id-overlay";
+    const sessionIdOverlay = document.createElement('div');
+    sessionIdOverlay.className = 'session-id-overlay';
     sessionIdOverlay.textContent = participantId;
     videoContainer.appendChild(sessionIdOverlay);
 
     // Create a video element for the participant
-    const videoEl = document.createElement("video");
-    videoEl.className = "video-element";
+    const videoEl = document.createElement('video');
+    videoEl.className = 'video-element';
     videoContainer.appendChild(videoEl);
   }
 
@@ -322,7 +322,7 @@ class DailyCallManager {
    */
   createAudioElement(participantId) {
     // Create an audio element for the participant
-    const audioEl = document.createElement("audio");
+    const audioEl = document.createElement('audio');
     audioEl.id = `audio-${participantId}`;
     document.body.appendChild(audioEl);
   }
@@ -337,7 +337,7 @@ class DailyCallManager {
    */
   createCustomAudioElement(trackType, participantId) {
     // Create a custom audio element for the participant
-    const audioEl = document.createElement("audio");
+    const audioEl = document.createElement('audio');
     audioEl.id = `${trackType}-${participantId}`;
     audioEl.autoplay = true;
     document.body.appendChild(audioEl);
@@ -353,21 +353,21 @@ class DailyCallManager {
    */
   createCustomVideoContainer(trackType, participantId) {
     // Create a video container for the custom video track
-    const videoContainer = document.createElement("div");
+    const videoContainer = document.createElement('div');
     videoContainer.id = `video-container-${trackType}-${participantId}`;
-    videoContainer.className = "video-container";
-    document.getElementById("videos").appendChild(videoContainer);
+    videoContainer.className = 'video-container';
+    document.getElementById('videos').appendChild(videoContainer);
 
     // Add an overlay to display the track name and participant's session ID
-    const sessionIdOverlay = document.createElement("div");
-    sessionIdOverlay.className = "session-id-overlay";
-    const trackName = trackType.replace("customVideo", "");
+    const sessionIdOverlay = document.createElement('div');
+    sessionIdOverlay.className = 'session-id-overlay';
+    const trackName = trackType.replace('customVideo', '');
     sessionIdOverlay.textContent = `${trackName} (${participantId})`;
     videoContainer.appendChild(sessionIdOverlay);
 
     // Create a video element for the custom video track
-    const videoEl = document.createElement("video");
-    videoEl.className = "video-element";
+    const videoEl = document.createElement('video');
+    videoEl.className = 'video-element';
     videoEl.autoplay = true;
     videoEl.muted = true;
     videoEl.playsInline = true;
@@ -394,15 +394,15 @@ class DailyCallManager {
     // For custom audio and video tracks, we'll use a unique ID based on the track type
     let selector;
     console.log(
-      "Starting or updating track:",
+      'Starting or updating track:',
       trackType,
-      "for participant:",
+      'for participant:',
       participantId,
       track
     );
     const isCustomTrack = track.kind;
-    const isCustomAudio = isCustomTrack && track.kind === "audio";
-    const isCustomVideo = isCustomTrack && track.kind === "video";
+    const isCustomAudio = isCustomTrack && track.kind === 'audio';
+    const isCustomVideo = isCustomTrack && track.kind === 'video';
 
     if (isCustomAudio) {
       // Custom audio tracks get their own dedicated audio element
@@ -410,8 +410,8 @@ class DailyCallManager {
     } else if (isCustomVideo) {
       // Custom video tracks get their own dedicated video element in a custom container
       selector = `#video-container-${trackType}-${participantId} video.video-element`;
-      console.log("Custom video selector:", selector);
-    } else if (trackType === "video") {
+      console.log('Custom video selector:', selector);
+    } else if (trackType === 'video') {
       selector = `#video-container-${participantId} video.video-element`;
     } else {
       // Regular audio track
@@ -420,7 +420,7 @@ class DailyCallManager {
 
     // Retrieve the specific media element from the DOM.
     const trackEl =
-      trackType === "video" || isCustomVideo
+      trackType === 'video' || isCustomVideo
         ? document.querySelector(selector)
         : document.getElementById(selector);
 
@@ -474,9 +474,9 @@ class DailyCallManager {
    * @param {string} participantId - The ID of the participant.
    * @param {string} trackType - The type of track (e.g., 'video', 'customVideo-mytrack').
    */
-  updateVideoUi(track, participantId, trackType = "video") {
+  updateVideoUi(track, participantId, trackType = 'video') {
     // Determine the correct container ID based on track type
-    const isCustomVideo = track.customTrack && track.kind === "video";
+    const isCustomVideo = track.customTrack && track.kind === 'video';
     const containerId = isCustomVideo
       ? `video-container-${trackType}-${participantId}`
       : `video-container-${participantId}`;
@@ -487,23 +487,23 @@ class DailyCallManager {
       return;
     }
 
-    const videoEl = videoContainer.querySelector("video.video-element");
+    const videoEl = videoContainer.querySelector('video.video-element');
     if (!videoEl) {
       console.error(`Video element not found in container ${containerId}`);
       return;
     }
 
     switch (track.state) {
-      case "off":
-      case "interrupted":
-      case "blocked":
-        videoEl.style.display = "none"; // Hide video but keep container
+      case 'off':
+      case 'interrupted':
+      case 'blocked':
+        videoEl.style.display = 'none'; // Hide video but keep container
         break;
-      case "playable":
+      case 'playable':
       default:
         // Here we handle all other states the same as we handle 'playable'.
         // In your code, you may choose to handle them differently.
-        videoEl.style.display = "";
+        videoEl.style.display = '';
         break;
     }
   }
@@ -523,10 +523,10 @@ class DailyCallManager {
       const isCustomTrack = trackInfo && trackInfo.kind;
 
       // Determine the correct element ID based on track type
-      if (isCustomTrack && trackInfo.kind === "audio") {
+      if (isCustomTrack && trackInfo.kind === 'audio') {
         // Custom audio tracks have dedicated audio elements
         elementId = `${trackType}-${participantId}`;
-      } else if (isCustomTrack && trackInfo.kind === "video") {
+      } else if (isCustomTrack && trackInfo.kind === 'video') {
         // Custom video tracks have dedicated video containers
         elementId = `video-container-${trackType}-${participantId}`;
       } else {
@@ -537,9 +537,9 @@ class DailyCallManager {
       const element = document.getElementById(elementId);
       if (element) {
         // For video containers, clean up the video element inside
-        const isCustomVideo = isCustomTrack && trackInfo.kind === "video";
-        if (trackType === "video" || isCustomVideo) {
-          const videoEl = element.querySelector("video.video-element");
+        const isCustomVideo = isCustomTrack && trackInfo.kind === 'video';
+        if (trackType === 'video' || isCustomVideo) {
+          const videoEl = element.querySelector('video.video-element');
           if (videoEl) {
             videoEl.srcObject = null;
           }
@@ -577,32 +577,32 @@ class DailyCallManager {
     const isCustomTrack = trackInfo && trackInfo.kind;
 
     // For video, set the camera state
-    if (trackType === "video") {
-      document.getElementById("camera-state").textContent = `Camera: ${
-        this.call.localVideo() ? "On" : "Off"
+    if (trackType === 'video') {
+      document.getElementById('camera-state').textContent = `Camera: ${
+        this.call.localVideo() ? 'On' : 'Off'
       }`;
-    } else if (trackType === "audio") {
+    } else if (trackType === 'audio') {
       // For audio, set the mic state
-      document.getElementById("mic-state").textContent = `Mic: ${
-        this.call.localAudio() ? "On" : "Off"
+      document.getElementById('mic-state').textContent = `Mic: ${
+        this.call.localAudio() ? 'On' : 'Off'
       }`;
-    } else if (isCustomTrack && trackInfo.kind === "audio") {
+    } else if (isCustomTrack && trackInfo.kind === 'audio') {
       // For custom audio tracks, update UI to show custom track name
       // Extract track name from trackType (format: customAudio-name)
-      const trackName = trackType.replace("customAudio-", "");
+      const trackName = trackType.replace('customAudio-', '');
       document.getElementById(
-        "mic-state"
+        'mic-state'
       ).textContent = `Custom Audio (${trackName}): ${
-        trackInfo.state === "playable" ? "On" : "Off"
+        trackInfo.state === 'playable' ? 'On' : 'Off'
       }`;
-    } else if (isCustomTrack && trackInfo.kind === "video") {
+    } else if (isCustomTrack && trackInfo.kind === 'video') {
       // For custom video tracks, update UI to show custom track name
       // Extract track name from trackType (format: customVideo-name)
-      const trackName = trackType.replace("customVideo-", "");
+      const trackName = trackType.replace('customVideo-', '');
       document.getElementById(
-        "camera-state"
+        'camera-state'
       ).textContent = `Custom Video (${trackName}): ${
-        trackInfo.state === "playable" ? "On" : "Off"
+        trackInfo.state === 'playable' ? 'On' : 'Off'
       }`;
     }
   }
@@ -619,17 +619,17 @@ class DailyCallManager {
 
     // Element references for camera and microphone selectors.
     const selectors = {
-      videoinput: document.getElementById("camera-selector"),
-      audioinput: document.getElementById("mic-selector"),
+      videoinput: document.getElementById('camera-selector'),
+      audioinput: document.getElementById('mic-selector'),
     };
 
     // Prepare selectors by clearing existing options and adding a
     // non-selectable prompt.
     Object.values(selectors).forEach((selector) => {
-      selector.innerHTML = "";
+      selector.innerHTML = '';
       const promptOption = new Option(
-        `Select a ${selector.id.includes("camera") ? "camera" : "microphone"}`,
-        "",
+        `Select a ${selector.id.includes('camera') ? 'camera' : 'microphone'}`,
+        '',
         true,
         true
       );
@@ -641,7 +641,7 @@ class DailyCallManager {
     allDevices.forEach((device) => {
       if (device.label && selectors[device.kind]) {
         const isSelected =
-          selectedDevices[device.kind === "videoinput" ? "camera" : "mic"]
+          selectedDevices[device.kind === 'videoinput' ? 'camera' : 'mic']
             .deviceId === device.deviceId;
         const option = new Option(
           device.label,
@@ -655,10 +655,10 @@ class DailyCallManager {
 
     // Listen for user device change requests.
     Object.entries(selectors).forEach(([deviceKind, selector]) => {
-      selector.addEventListener("change", async (e) => {
+      selector.addEventListener('change', async (e) => {
         const deviceId = e.target.value;
         const deviceOptions = {
-          [deviceKind === "videoinput" ? "videoDeviceId" : "audioDeviceId"]:
+          [deviceKind === 'videoinput' ? 'videoDeviceId' : 'audioDeviceId']:
             deviceId,
         };
         await this.call.setInputDevicesAsync(deviceOptions);
@@ -675,7 +675,7 @@ class DailyCallManager {
       this.call.participantCounts().present +
       this.call.participantCounts().hidden;
     document.getElementById(
-      "participant-count"
+      'participant-count'
     ).textContent = `Participants: ${participantCount}`;
   }
 
@@ -686,12 +686,12 @@ class DailyCallManager {
   async leave() {
     try {
       await this.call.leave();
-      document.querySelectorAll("#videos video, audio").forEach((el) => {
+      document.querySelectorAll('#videos video, audio').forEach((el) => {
         el.srcObject = null; // Release media resources
         el.remove(); // Remove the element from the DOM
       });
     } catch (e) {
-      console.error("Leaving failed", e);
+      console.error('Leaving failed', e);
     }
   }
 }
@@ -700,19 +700,19 @@ class DailyCallManager {
  * Main entry point: Setup and event listener bindings after the DOM is fully
  * loaded.
  */
-document.addEventListener("DOMContentLoaded", async () => {
+document.addEventListener('DOMContentLoaded', async () => {
   const dailyCallManager = new DailyCallManager();
 
   // Bind the join call action to the join button.
-  document.getElementById("join-btn").addEventListener("click", async () => {
-    const roomUrl = document.getElementById("room-url").value.trim();
+  document.getElementById('join-btn').addEventListener('click', async () => {
+    const roomUrl = document.getElementById('room-url').value.trim();
     const joinToken =
-      document.getElementById("join-token").value.trim() || null;
+      document.getElementById('join-token').value.trim() || null;
     await dailyCallManager.joinRoom(roomUrl, joinToken);
   });
 
   // Bind the leave call action to the leave button.
-  document.getElementById("leave-btn").addEventListener("click", () => {
+  document.getElementById('leave-btn').addEventListener('click', () => {
     dailyCallManager.leave();
   });
 });

--- a/samples/client-sdk/getting-started-daily-js/index.js
+++ b/samples/client-sdk/getting-started-daily-js/index.js
@@ -20,11 +20,11 @@ class DailyCallManager {
   async initialize() {
     this.setupEventListeners();
     document
-      .getElementById('toggle-camera')
-      .addEventListener('click', () => this.toggleCamera());
+      .getElementById("toggle-camera")
+      .addEventListener("click", () => this.toggleCamera());
     document
-      .getElementById('toggle-mic')
-      .addEventListener('click', () => this.toggleMicrophone());
+      .getElementById("toggle-mic")
+      .addEventListener("click", () => this.toggleMicrophone());
   }
 
   /**
@@ -32,13 +32,13 @@ class DailyCallManager {
    */
   setupEventListeners() {
     const events = {
-      'active-speaker-change': this.handleActiveSpeakerChange.bind(this),
+      "active-speaker-change": this.handleActiveSpeakerChange.bind(this),
       error: this.handleError.bind(this),
-      'joined-meeting': this.handleJoin.bind(this),
-      'left-meeting': this.handleLeave.bind(this),
-      'participant-joined': this.handleParticipantJoinedOrUpdated.bind(this),
-      'participant-left': this.handleParticipantLeft.bind(this),
-      'participant-updated': this.handleParticipantJoinedOrUpdated.bind(this),
+      "joined-meeting": this.handleJoin.bind(this),
+      "left-meeting": this.handleLeave.bind(this),
+      "participant-joined": this.handleParticipantJoinedOrUpdated.bind(this),
+      "participant-left": this.handleParticipantLeft.bind(this),
+      "participant-updated": this.handleParticipantJoinedOrUpdated.bind(this),
     };
 
     Object.entries(events).forEach(([event, handler]) => {
@@ -63,13 +63,13 @@ class DailyCallManager {
     this.updateAndDisplayParticipantCount();
 
     // Enable the leave button
-    document.getElementById('leave-btn').disabled = false;
+    document.getElementById("leave-btn").disabled = false;
 
     // Enable the toggle camera and mic buttons and selectors
-    document.getElementById('toggle-camera').disabled = false;
-    document.getElementById('toggle-mic').disabled = false;
-    document.getElementById('camera-selector').disabled = false;
-    document.getElementById('mic-selector').disabled = false;
+    document.getElementById("toggle-camera").disabled = false;
+    document.getElementById("toggle-mic").disabled = false;
+    document.getElementById("camera-selector").disabled = false;
+    document.getElementById("mic-selector").disabled = false;
 
     // Set up the camera and mic selectors
     this.setupDeviceSelectors();
@@ -90,36 +90,36 @@ class DailyCallManager {
    * - Removes all video containers
    */
   handleLeave() {
-    console.log('Successfully left the call');
+    console.log("Successfully left the call");
 
     // Update the join and leave button states
-    document.getElementById('leave-btn').disabled = true;
-    document.getElementById('join-btn').disabled = false;
+    document.getElementById("leave-btn").disabled = true;
+    document.getElementById("join-btn").disabled = false;
 
     // Disable the toggle camera and mic buttons
-    document.getElementById('toggle-camera').disabled = true;
-    document.getElementById('toggle-mic').disabled = true;
+    document.getElementById("toggle-camera").disabled = true;
+    document.getElementById("toggle-mic").disabled = true;
 
     // Reset and disable the camera and mic selectors
-    const cameraSelector = document.getElementById('camera-selector');
-    const micSelector = document.getElementById('mic-selector');
+    const cameraSelector = document.getElementById("camera-selector");
+    const micSelector = document.getElementById("mic-selector");
     cameraSelector.selectedIndex = 0;
     micSelector.selectedIndex = 0;
     cameraSelector.disabled = true;
     micSelector.disabled = true;
 
     // Update the call state in the UI
-    document.getElementById('camera-state').textContent = 'Camera: Off';
-    document.getElementById('mic-state').textContent = 'Mic: Off';
+    document.getElementById("camera-state").textContent = "Camera: Off";
+    document.getElementById("mic-state").textContent = "Mic: Off";
     document.getElementById(
-      'participant-count'
+      "participant-count"
     ).textContent = `Participants: 0`;
     document.getElementById(
-      'active-speaker'
+      "active-speaker"
     ).textContent = `Active Speaker: None`;
 
     // Remove all video containers
-    const videosDiv = document.getElementById('videos');
+    const videosDiv = document.getElementById("videos");
     while (videosDiv.firstChild) {
       videosDiv.removeChild(videosDiv.firstChild);
     }
@@ -133,7 +133,7 @@ class DailyCallManager {
    * @param {Object} e - The error event object.
    */
   handleError(e) {
-    console.error('DAILY SENT AN ERROR!', e.error ? e.error : e.errorMsg);
+    console.error("DAILY SENT AN ERROR!", e.error ? e.error : e.errorMsg);
   }
 
   /**
@@ -149,14 +149,17 @@ class DailyCallManager {
     // When a participant leaves, we don't have trackInfo, but we know these are regular tracks
     this.destroyTracks(
       [
-        { trackType: 'video', trackInfo: null },
-        { trackType: 'audio', trackInfo: null },
+        { trackType: "video", trackInfo: null },
+        { trackType: "audio", trackInfo: null },
       ],
       participantId
     );
 
     // Now, remove the related video UI
     document.getElementById(`video-container-${participantId}`)?.remove();
+    document
+      .getElementById(`video-container-customTrack-${participantId}`)
+      ?.remove();
 
     // Update the participant count
     this.updateAndDisplayParticipantCount();
@@ -198,11 +201,8 @@ class DailyCallManager {
     Object.entries(tracks).forEach(([trackType, trackInfo]) => {
       // If a persistentTrack exists...
       if (trackInfo.persistentTrack) {
-        // Check if this is a custom track
-        const isCustomTrack = trackInfo.kind;
-
         // For custom audio tracks, create a dedicated audio element if it doesn't exist
-        if (isCustomTrack && trackInfo.kind === 'audio' && !isLocal) {
+        if (trackInfo?.kind === "audio" && !isLocal) {
           const customAudioId = `${trackType}-${participantId}`;
           if (!document.getElementById(customAudioId)) {
             this.createCustomAudioElement(trackType, participantId);
@@ -210,7 +210,7 @@ class DailyCallManager {
         }
 
         // For custom video tracks, create a dedicated video container if it doesn't exist
-        if (isCustomTrack && trackInfo.kind === 'video') {
+        if (trackInfo?.kind === "video") {
           const customVideoId = `video-container-${trackType}-${participantId}`;
           if (!document.getElementById(customVideoId)) {
             this.createCustomVideoContainer(trackType, participantId);
@@ -220,7 +220,7 @@ class DailyCallManager {
         // Check if this is the local participant's audio track.
         // If so, we will skip playing it, as it's already being played.
         // We'll start or update tracks in all other cases.
-        if (!(isLocal && trackType === 'audio')) {
+        if (!(isLocal && trackType === "audio")) {
           this.startOrUpdateTrack(trackType, trackInfo, participantId);
         }
       } else {
@@ -230,7 +230,7 @@ class DailyCallManager {
 
       // Update the video UI based on the track's state
       // For regular and custom video tracks
-      if (trackType === 'video' || trackInfo.kind === 'video') {
+      if (trackType === "video" || trackInfo?.kind === "video") {
         this.updateVideoUi(trackInfo, participantId, trackType);
       }
 
@@ -248,7 +248,7 @@ class DailyCallManager {
    */
   handleActiveSpeakerChange(event) {
     document.getElementById(
-      'active-speaker'
+      "active-speaker"
     ).textContent = `Active Speaker: ${event.activeSpeaker.peerId}`;
   }
 
@@ -259,7 +259,7 @@ class DailyCallManager {
    */
   async joinRoom(roomUrl, joinToken = null) {
     if (!roomUrl) {
-      console.error('Room URL is required to join a room.');
+      console.error("Room URL is required to join a room.");
       return;
     }
 
@@ -268,18 +268,18 @@ class DailyCallManager {
     const joinOptions = { url: roomUrl };
     if (joinToken) {
       joinOptions.token = joinToken;
-      console.log('Joining with a token.');
+      console.log("Joining with a token.");
     } else {
-      console.log('Joining without a token.');
+      console.log("Joining without a token.");
     }
 
     try {
       // Disable the join button to prevent multiple attempts to join
-      document.getElementById('join-btn').disabled = true;
+      document.getElementById("join-btn").disabled = true;
       // Join the room
       await this.call.join(joinOptions);
     } catch (e) {
-      console.error('Join failed:', e);
+      console.error("Join failed:", e);
     }
   }
 
@@ -294,20 +294,20 @@ class DailyCallManager {
    */
   createVideoContainer(participantId) {
     // Create a video container for the participant
-    const videoContainer = document.createElement('div');
+    const videoContainer = document.createElement("div");
     videoContainer.id = `video-container-${participantId}`;
-    videoContainer.className = 'video-container';
-    document.getElementById('videos').appendChild(videoContainer);
+    videoContainer.className = "video-container";
+    document.getElementById("videos").appendChild(videoContainer);
 
     // Add an overlay to display the participant's session ID
-    const sessionIdOverlay = document.createElement('div');
-    sessionIdOverlay.className = 'session-id-overlay';
+    const sessionIdOverlay = document.createElement("div");
+    sessionIdOverlay.className = "session-id-overlay";
     sessionIdOverlay.textContent = participantId;
     videoContainer.appendChild(sessionIdOverlay);
 
     // Create a video element for the participant
-    const videoEl = document.createElement('video');
-    videoEl.className = 'video-element';
+    const videoEl = document.createElement("video");
+    videoEl.className = "video-element";
     videoContainer.appendChild(videoEl);
   }
 
@@ -322,7 +322,7 @@ class DailyCallManager {
    */
   createAudioElement(participantId) {
     // Create an audio element for the participant
-    const audioEl = document.createElement('audio');
+    const audioEl = document.createElement("audio");
     audioEl.id = `audio-${participantId}`;
     document.body.appendChild(audioEl);
   }
@@ -337,7 +337,7 @@ class DailyCallManager {
    */
   createCustomAudioElement(trackType, participantId) {
     // Create a custom audio element for the participant
-    const audioEl = document.createElement('audio');
+    const audioEl = document.createElement("audio");
     audioEl.id = `${trackType}-${participantId}`;
     audioEl.autoplay = true;
     document.body.appendChild(audioEl);
@@ -353,21 +353,21 @@ class DailyCallManager {
    */
   createCustomVideoContainer(trackType, participantId) {
     // Create a video container for the custom video track
-    const videoContainer = document.createElement('div');
+    const videoContainer = document.createElement("div");
     videoContainer.id = `video-container-${trackType}-${participantId}`;
-    videoContainer.className = 'video-container';
-    document.getElementById('videos').appendChild(videoContainer);
+    videoContainer.className = "video-container";
+    document.getElementById("videos").appendChild(videoContainer);
 
     // Add an overlay to display the track name and participant's session ID
-    const sessionIdOverlay = document.createElement('div');
-    sessionIdOverlay.className = 'session-id-overlay';
-    const trackName = trackType.replace('customVideo', '');
+    const sessionIdOverlay = document.createElement("div");
+    sessionIdOverlay.className = "session-id-overlay";
+    const trackName = trackType.replace("customVideo", "");
     sessionIdOverlay.textContent = `${trackName} (${participantId})`;
     videoContainer.appendChild(sessionIdOverlay);
 
     // Create a video element for the custom video track
-    const videoEl = document.createElement('video');
-    videoEl.className = 'video-element';
+    const videoEl = document.createElement("video");
+    videoEl.className = "video-element";
     videoEl.autoplay = true;
     videoEl.muted = true;
     videoEl.playsInline = true;
@@ -394,15 +394,14 @@ class DailyCallManager {
     // For custom audio and video tracks, we'll use a unique ID based on the track type
     let selector;
     console.log(
-      'Starting or updating track:',
+      "Starting or updating track:",
       trackType,
-      'for participant:',
+      "for participant:",
       participantId,
       track
     );
-    const isCustomTrack = track.kind;
-    const isCustomAudio = isCustomTrack && track.kind === 'audio';
-    const isCustomVideo = isCustomTrack && track.kind === 'video';
+    const isCustomAudio = track.kind === "audio";
+    const isCustomVideo = track.kind === "video";
 
     if (isCustomAudio) {
       // Custom audio tracks get their own dedicated audio element
@@ -410,8 +409,8 @@ class DailyCallManager {
     } else if (isCustomVideo) {
       // Custom video tracks get their own dedicated video element in a custom container
       selector = `#video-container-${trackType}-${participantId} video.video-element`;
-      console.log('Custom video selector:', selector);
-    } else if (trackType === 'video') {
+      console.log("Custom video selector:", selector);
+    } else if (trackType === "video") {
       selector = `#video-container-${participantId} video.video-element`;
     } else {
       // Regular audio track
@@ -420,7 +419,7 @@ class DailyCallManager {
 
     // Retrieve the specific media element from the DOM.
     const trackEl =
-      trackType === 'video' || isCustomVideo
+      trackType === "video" || isCustomVideo
         ? document.querySelector(selector)
         : document.getElementById(selector);
 
@@ -474,9 +473,9 @@ class DailyCallManager {
    * @param {string} participantId - The ID of the participant.
    * @param {string} trackType - The type of track (e.g., 'video', 'customVideo-mytrack').
    */
-  updateVideoUi(track, participantId, trackType = 'video') {
+  updateVideoUi(track, participantId, trackType = "video") {
     // Determine the correct container ID based on track type
-    const isCustomVideo = track.customTrack && track.kind === 'video';
+    const isCustomVideo = track.customTrack && track.kind === "video";
     const containerId = isCustomVideo
       ? `video-container-${trackType}-${participantId}`
       : `video-container-${participantId}`;
@@ -487,23 +486,23 @@ class DailyCallManager {
       return;
     }
 
-    const videoEl = videoContainer.querySelector('video.video-element');
+    const videoEl = videoContainer.querySelector("video.video-element");
     if (!videoEl) {
       console.error(`Video element not found in container ${containerId}`);
       return;
     }
 
     switch (track.state) {
-      case 'off':
-      case 'interrupted':
-      case 'blocked':
-        videoEl.style.display = 'none'; // Hide video but keep container
+      case "off":
+      case "interrupted":
+      case "blocked":
+        videoEl.style.display = "none"; // Hide video but keep container
         break;
-      case 'playable':
+      case "playable":
       default:
         // Here we handle all other states the same as we handle 'playable'.
         // In your code, you may choose to handle them differently.
-        videoEl.style.display = '';
+        videoEl.style.display = "";
         break;
     }
   }
@@ -520,13 +519,12 @@ class DailyCallManager {
   destroyTracks(trackData, participantId) {
     trackData.forEach(({ trackType, trackInfo }) => {
       let elementId;
-      const isCustomTrack = trackInfo && trackInfo.kind;
 
       // Determine the correct element ID based on track type
-      if (isCustomTrack && trackInfo.kind === 'audio') {
+      if (trackInfo?.kind === "audio") {
         // Custom audio tracks have dedicated audio elements
         elementId = `${trackType}-${participantId}`;
-      } else if (isCustomTrack && trackInfo.kind === 'video') {
+      } else if (trackInfo?.kind === "video") {
         // Custom video tracks have dedicated video containers
         elementId = `video-container-${trackType}-${participantId}`;
       } else {
@@ -537,9 +535,9 @@ class DailyCallManager {
       const element = document.getElementById(elementId);
       if (element) {
         // For video containers, clean up the video element inside
-        const isCustomVideo = isCustomTrack && trackInfo.kind === 'video';
-        if (trackType === 'video' || isCustomVideo) {
-          const videoEl = element.querySelector('video.video-element');
+        const isCustomVideo = trackInfo?.kind === "video";
+        if (trackType === "video" || isCustomVideo) {
+          const videoEl = element.querySelector("video.video-element");
           if (videoEl) {
             videoEl.srcObject = null;
           }
@@ -574,35 +572,33 @@ class DailyCallManager {
    * @param {Object} trackInfo - The track object.
    */
   updateUiForDevicesState(trackType, trackInfo) {
-    const isCustomTrack = trackInfo && trackInfo.kind;
-
     // For video, set the camera state
-    if (trackType === 'video') {
-      document.getElementById('camera-state').textContent = `Camera: ${
-        this.call.localVideo() ? 'On' : 'Off'
+    if (trackType === "video") {
+      document.getElementById("camera-state").textContent = `Camera: ${
+        this.call.localVideo() ? "On" : "Off"
       }`;
-    } else if (trackType === 'audio') {
+    } else if (trackType === "audio") {
       // For audio, set the mic state
-      document.getElementById('mic-state').textContent = `Mic: ${
-        this.call.localAudio() ? 'On' : 'Off'
+      document.getElementById("mic-state").textContent = `Mic: ${
+        this.call.localAudio() ? "On" : "Off"
       }`;
-    } else if (isCustomTrack && trackInfo.kind === 'audio') {
+    } else if (trackInfo?.kind === "audio") {
       // For custom audio tracks, update UI to show custom track name
       // Extract track name from trackType (format: customAudio-name)
-      const trackName = trackType.replace('customAudio-', '');
+      const trackName = trackType.replace("customAudio-", "");
       document.getElementById(
-        'mic-state'
+        "mic-state"
       ).textContent = `Custom Audio (${trackName}): ${
-        trackInfo.state === 'playable' ? 'On' : 'Off'
+        trackInfo.state === "playable" ? "On" : "Off"
       }`;
-    } else if (isCustomTrack && trackInfo.kind === 'video') {
+    } else if (trackInfo?.kind === "video") {
       // For custom video tracks, update UI to show custom track name
       // Extract track name from trackType (format: customVideo-name)
-      const trackName = trackType.replace('customVideo-', '');
+      const trackName = trackType.replace("customVideo-", "");
       document.getElementById(
-        'camera-state'
+        "camera-state"
       ).textContent = `Custom Video (${trackName}): ${
-        trackInfo.state === 'playable' ? 'On' : 'Off'
+        trackInfo.state === "playable" ? "On" : "Off"
       }`;
     }
   }
@@ -619,17 +615,17 @@ class DailyCallManager {
 
     // Element references for camera and microphone selectors.
     const selectors = {
-      videoinput: document.getElementById('camera-selector'),
-      audioinput: document.getElementById('mic-selector'),
+      videoinput: document.getElementById("camera-selector"),
+      audioinput: document.getElementById("mic-selector"),
     };
 
     // Prepare selectors by clearing existing options and adding a
     // non-selectable prompt.
     Object.values(selectors).forEach((selector) => {
-      selector.innerHTML = '';
+      selector.innerHTML = "";
       const promptOption = new Option(
-        `Select a ${selector.id.includes('camera') ? 'camera' : 'microphone'}`,
-        '',
+        `Select a ${selector.id.includes("camera") ? "camera" : "microphone"}`,
+        "",
         true,
         true
       );
@@ -641,7 +637,7 @@ class DailyCallManager {
     allDevices.forEach((device) => {
       if (device.label && selectors[device.kind]) {
         const isSelected =
-          selectedDevices[device.kind === 'videoinput' ? 'camera' : 'mic']
+          selectedDevices[device.kind === "videoinput" ? "camera" : "mic"]
             .deviceId === device.deviceId;
         const option = new Option(
           device.label,
@@ -655,10 +651,10 @@ class DailyCallManager {
 
     // Listen for user device change requests.
     Object.entries(selectors).forEach(([deviceKind, selector]) => {
-      selector.addEventListener('change', async (e) => {
+      selector.addEventListener("change", async (e) => {
         const deviceId = e.target.value;
         const deviceOptions = {
-          [deviceKind === 'videoinput' ? 'videoDeviceId' : 'audioDeviceId']:
+          [deviceKind === "videoinput" ? "videoDeviceId" : "audioDeviceId"]:
             deviceId,
         };
         await this.call.setInputDevicesAsync(deviceOptions);
@@ -675,7 +671,7 @@ class DailyCallManager {
       this.call.participantCounts().present +
       this.call.participantCounts().hidden;
     document.getElementById(
-      'participant-count'
+      "participant-count"
     ).textContent = `Participants: ${participantCount}`;
   }
 
@@ -686,12 +682,12 @@ class DailyCallManager {
   async leave() {
     try {
       await this.call.leave();
-      document.querySelectorAll('#videos video, audio').forEach((el) => {
+      document.querySelectorAll("#videos video, audio").forEach((el) => {
         el.srcObject = null; // Release media resources
         el.remove(); // Remove the element from the DOM
       });
     } catch (e) {
-      console.error('Leaving failed', e);
+      console.error("Leaving failed", e);
     }
   }
 }
@@ -700,19 +696,19 @@ class DailyCallManager {
  * Main entry point: Setup and event listener bindings after the DOM is fully
  * loaded.
  */
-document.addEventListener('DOMContentLoaded', async () => {
+document.addEventListener("DOMContentLoaded", async () => {
   const dailyCallManager = new DailyCallManager();
 
   // Bind the join call action to the join button.
-  document.getElementById('join-btn').addEventListener('click', async () => {
-    const roomUrl = document.getElementById('room-url').value.trim();
+  document.getElementById("join-btn").addEventListener("click", async () => {
+    const roomUrl = document.getElementById("room-url").value.trim();
     const joinToken =
-      document.getElementById('join-token').value.trim() || null;
+      document.getElementById("join-token").value.trim() || null;
     await dailyCallManager.joinRoom(roomUrl, joinToken);
   });
 
   // Bind the leave call action to the leave button.
-  document.getElementById('leave-btn').addEventListener('click', () => {
+  document.getElementById("leave-btn").addEventListener("click", () => {
     dailyCallManager.leave();
   });
 });

--- a/samples/client-sdk/getting-started-daily-js/index.js
+++ b/samples/client-sdk/getting-started-daily-js/index.js
@@ -6,7 +6,10 @@
  */
 class DailyCallManager {
   constructor() {
-    this.call = Daily.createCallObject();
+    this.call = Daily.createCallObject({
+      subscribeToTracksAutomatically: false,
+    });
+    window.callObject = this.call; // Expose for debugging
     this.currentRoomUrl = null;
     this.initialize();
   }
@@ -17,11 +20,11 @@ class DailyCallManager {
   async initialize() {
     this.setupEventListeners();
     document
-      .getElementById('toggle-camera')
-      .addEventListener('click', () => this.toggleCamera());
+      .getElementById("toggle-camera")
+      .addEventListener("click", () => this.toggleCamera());
     document
-      .getElementById('toggle-mic')
-      .addEventListener('click', () => this.toggleMicrophone());
+      .getElementById("toggle-mic")
+      .addEventListener("click", () => this.toggleMicrophone());
   }
 
   /**
@@ -29,13 +32,13 @@ class DailyCallManager {
    */
   setupEventListeners() {
     const events = {
-      'active-speaker-change': this.handleActiveSpeakerChange.bind(this),
+      "active-speaker-change": this.handleActiveSpeakerChange.bind(this),
       error: this.handleError.bind(this),
-      'joined-meeting': this.handleJoin.bind(this),
-      'left-meeting': this.handleLeave.bind(this),
-      'participant-joined': this.handleParticipantJoinedOrUpdated.bind(this),
-      'participant-left': this.handleParticipantLeft.bind(this),
-      'participant-updated': this.handleParticipantJoinedOrUpdated.bind(this),
+      "joined-meeting": this.handleJoin.bind(this),
+      "left-meeting": this.handleLeave.bind(this),
+      "participant-joined": this.handleParticipantJoinedOrUpdated.bind(this),
+      "participant-left": this.handleParticipantLeft.bind(this),
+      "participant-updated": this.handleParticipantJoinedOrUpdated.bind(this),
     };
 
     Object.entries(events).forEach(([event, handler]) => {
@@ -52,7 +55,7 @@ class DailyCallManager {
    * @param {Object} event - The joined-meeting event object.
    */
   handleJoin(event) {
-    const tracks = event.participants.local.tracks;
+    const { tracks } = event.participants.local;
 
     console.log(`Successfully joined: ${this.currentRoomUrl}`);
 
@@ -60,13 +63,13 @@ class DailyCallManager {
     this.updateAndDisplayParticipantCount();
 
     // Enable the leave button
-    document.getElementById('leave-btn').disabled = false;
+    document.getElementById("leave-btn").disabled = false;
 
     // Enable the toggle camera and mic buttons and selectors
-    document.getElementById('toggle-camera').disabled = false;
-    document.getElementById('toggle-mic').disabled = false;
-    document.getElementById('camera-selector').disabled = false;
-    document.getElementById('mic-selector').disabled = false;
+    document.getElementById("toggle-camera").disabled = false;
+    document.getElementById("toggle-mic").disabled = false;
+    document.getElementById("camera-selector").disabled = false;
+    document.getElementById("mic-selector").disabled = false;
 
     // Set up the camera and mic selectors
     this.setupDeviceSelectors();
@@ -87,36 +90,36 @@ class DailyCallManager {
    * - Removes all video containers
    */
   handleLeave() {
-    console.log('Successfully left the call');
+    console.log("Successfully left the call");
 
     // Update the join and leave button states
-    document.getElementById('leave-btn').disabled = true;
-    document.getElementById('join-btn').disabled = false;
+    document.getElementById("leave-btn").disabled = true;
+    document.getElementById("join-btn").disabled = false;
 
     // Disable the toggle camera and mic buttons
-    document.getElementById('toggle-camera').disabled = true;
-    document.getElementById('toggle-mic').disabled = true;
+    document.getElementById("toggle-camera").disabled = true;
+    document.getElementById("toggle-mic").disabled = true;
 
     // Reset and disable the camera and mic selectors
-    const cameraSelector = document.getElementById('camera-selector');
-    const micSelector = document.getElementById('mic-selector');
+    const cameraSelector = document.getElementById("camera-selector");
+    const micSelector = document.getElementById("mic-selector");
     cameraSelector.selectedIndex = 0;
     micSelector.selectedIndex = 0;
     cameraSelector.disabled = true;
     micSelector.disabled = true;
 
     // Update the call state in the UI
-    document.getElementById('camera-state').textContent = 'Camera: Off';
-    document.getElementById('mic-state').textContent = 'Mic: Off';
+    document.getElementById("camera-state").textContent = "Camera: Off";
+    document.getElementById("mic-state").textContent = "Mic: Off";
     document.getElementById(
-      'participant-count'
+      "participant-count"
     ).textContent = `Participants: 0`;
     document.getElementById(
-      'active-speaker'
+      "active-speaker"
     ).textContent = `Active Speaker: None`;
 
     // Remove all video containers
-    const videosDiv = document.getElementById('videos');
+    const videosDiv = document.getElementById("videos");
     while (videosDiv.firstChild) {
       videosDiv.removeChild(videosDiv.firstChild);
     }
@@ -130,7 +133,7 @@ class DailyCallManager {
    * @param {Object} e - The error event object.
    */
   handleError(e) {
-    console.error('DAILY SENT AN ERROR!', e.error ? e.error : e.errorMsg);
+    console.error("DAILY SENT AN ERROR!", e.error ? e.error : e.errorMsg);
   }
 
   /**
@@ -143,7 +146,14 @@ class DailyCallManager {
     const participantId = event.participant.session_id;
 
     // Clean up the video and audio tracks for the participant
-    this.destroyTracks(['video', 'audio'], participantId);
+    // When a participant leaves, we don't have trackInfo, but we know these are regular tracks
+    this.destroyTracks(
+      [
+        { trackType: "video", trackInfo: null },
+        { trackType: "audio", trackInfo: null },
+      ],
+      participantId
+    );
 
     // Now, remove the related video UI
     document.getElementById(`video-container-${participantId}`)?.remove();
@@ -166,7 +176,11 @@ class DailyCallManager {
     const { participant } = event;
     const participantId = participant.session_id;
     const isLocal = participant.local;
-    const tracks = participant.tracks;
+    const { tracks } = participant;
+
+    this.call.updateParticipant(participantId, {
+      setSubscribedTracks: true,
+    });
 
     // Always update the participant count regardless of the event action
     this.updateAndDisplayParticipantCount();
@@ -184,20 +198,40 @@ class DailyCallManager {
     Object.entries(tracks).forEach(([trackType, trackInfo]) => {
       // If a persistentTrack exists...
       if (trackInfo.persistentTrack) {
+        // Check if this is a custom track
+        const isCustomTrack = trackInfo.kind;
+
+        // For custom audio tracks, create a dedicated audio element if it doesn't exist
+        if (isCustomTrack && trackInfo.kind === "audio" && !isLocal) {
+          const customAudioId = `${trackType}-${participantId}`;
+          if (!document.getElementById(customAudioId)) {
+            this.createCustomAudioElement(trackType, participantId);
+          }
+        }
+
+        // For custom video tracks, create a dedicated video container if it doesn't exist
+        if (isCustomTrack && trackInfo.kind === "video") {
+          const customVideoId = `video-container-${trackType}-${participantId}`;
+          if (!document.getElementById(customVideoId)) {
+            this.createCustomVideoContainer(trackType, participantId);
+          }
+        }
+
         // Check if this is the local participant's audio track.
         // If so, we will skip playing it, as it's already being played.
         // We'll start or update tracks in all other cases.
-        if (!(isLocal && trackType === 'audio')) {
+        if (!(isLocal && trackType === "audio")) {
           this.startOrUpdateTrack(trackType, trackInfo, participantId);
         }
       } else {
         // If the track is not available, remove the media element
-        this.destroyTracks([trackType], participantId);
+        this.destroyTracks([{ trackType, trackInfo }], participantId);
       }
 
       // Update the video UI based on the track's state
-      if (trackType === 'video') {
-        this.updateVideoUi(trackInfo, participantId);
+      // For regular and custom video tracks
+      if (trackType === "video" || trackInfo.kind === "video") {
+        this.updateVideoUi(trackInfo, participantId, trackType);
       }
 
       // Update the camera and microphone states for the local user based on
@@ -214,7 +248,7 @@ class DailyCallManager {
    */
   handleActiveSpeakerChange(event) {
     document.getElementById(
-      'active-speaker'
+      "active-speaker"
     ).textContent = `Active Speaker: ${event.activeSpeaker.peerId}`;
   }
 
@@ -225,7 +259,7 @@ class DailyCallManager {
    */
   async joinRoom(roomUrl, joinToken = null) {
     if (!roomUrl) {
-      console.error('Room URL is required to join a room.');
+      console.error("Room URL is required to join a room.");
       return;
     }
 
@@ -234,18 +268,18 @@ class DailyCallManager {
     const joinOptions = { url: roomUrl };
     if (joinToken) {
       joinOptions.token = joinToken;
-      console.log('Joining with a token.');
+      console.log("Joining with a token.");
     } else {
-      console.log('Joining without a token.');
+      console.log("Joining without a token.");
     }
 
     try {
       // Disable the join button to prevent multiple attempts to join
-      document.getElementById('join-btn').disabled = true;
+      document.getElementById("join-btn").disabled = true;
       // Join the room
       await this.call.join(joinOptions);
     } catch (e) {
-      console.error('Join failed:', e);
+      console.error("Join failed:", e);
     }
   }
 
@@ -260,20 +294,20 @@ class DailyCallManager {
    */
   createVideoContainer(participantId) {
     // Create a video container for the participant
-    const videoContainer = document.createElement('div');
+    const videoContainer = document.createElement("div");
     videoContainer.id = `video-container-${participantId}`;
-    videoContainer.className = 'video-container';
-    document.getElementById('videos').appendChild(videoContainer);
+    videoContainer.className = "video-container";
+    document.getElementById("videos").appendChild(videoContainer);
 
     // Add an overlay to display the participant's session ID
-    const sessionIdOverlay = document.createElement('div');
-    sessionIdOverlay.className = 'session-id-overlay';
+    const sessionIdOverlay = document.createElement("div");
+    sessionIdOverlay.className = "session-id-overlay";
     sessionIdOverlay.textContent = participantId;
     videoContainer.appendChild(sessionIdOverlay);
 
     // Create a video element for the participant
-    const videoEl = document.createElement('video');
-    videoEl.className = 'video-element';
+    const videoEl = document.createElement("video");
+    videoEl.className = "video-element";
     videoContainer.appendChild(videoEl);
   }
 
@@ -288,9 +322,56 @@ class DailyCallManager {
    */
   createAudioElement(participantId) {
     // Create an audio element for the participant
-    const audioEl = document.createElement('audio');
+    const audioEl = document.createElement("audio");
     audioEl.id = `audio-${participantId}`;
     document.body.appendChild(audioEl);
+  }
+
+  /**
+   * Creates a custom audio element for a particular participant and track type.
+   * This function is responsible for dynamically generating a standalone audio element
+   * that can be used to play custom audio streams associated with the specified participant.
+   *
+   * @param {string} trackType - The custom audio track type (e.g., 'customAudio-mytrack').
+   * @param {string} participantId - A unique identifier corresponding to the participant.
+   */
+  createCustomAudioElement(trackType, participantId) {
+    // Create a custom audio element for the participant
+    const audioEl = document.createElement("audio");
+    audioEl.id = `${trackType}-${participantId}`;
+    audioEl.autoplay = true;
+    document.body.appendChild(audioEl);
+  }
+
+  /**
+   * Creates a custom video container for a particular participant and track type.
+   * This function dynamically generates a video element with a container and overlay
+   * for custom video tracks.
+   *
+   * @param {string} trackType - The custom video track type (e.g., 'customVideo-mytrack').
+   * @param {string} participantId - A unique identifier corresponding to the participant.
+   */
+  createCustomVideoContainer(trackType, participantId) {
+    // Create a video container for the custom video track
+    const videoContainer = document.createElement("div");
+    videoContainer.id = `video-container-${trackType}-${participantId}`;
+    videoContainer.className = "video-container";
+    document.getElementById("videos").appendChild(videoContainer);
+
+    // Add an overlay to display the track name and participant's session ID
+    const sessionIdOverlay = document.createElement("div");
+    sessionIdOverlay.className = "session-id-overlay";
+    const trackName = trackType.replace("customVideo", "");
+    sessionIdOverlay.textContent = `${trackName} (${participantId})`;
+    videoContainer.appendChild(sessionIdOverlay);
+
+    // Create a video element for the custom video track
+    const videoEl = document.createElement("video");
+    videoEl.className = "video-element";
+    videoEl.autoplay = true;
+    videoEl.muted = true;
+    videoEl.playsInline = true;
+    videoContainer.appendChild(videoEl);
   }
 
   /**
@@ -310,14 +391,36 @@ class DailyCallManager {
    */
   startOrUpdateTrack(trackType, track, participantId) {
     // Construct the selector string or ID based on the trackType.
-    const selector =
-      trackType === 'video'
-        ? `#video-container-${participantId} video.video-element`
-        : `audio-${participantId}`;
+    // For custom audio and video tracks, we'll use a unique ID based on the track type
+    let selector;
+    console.log(
+      "Starting or updating track:",
+      trackType,
+      "for participant:",
+      participantId,
+      track
+    );
+    const isCustomTrack = track.kind;
+    const isCustomAudio = isCustomTrack && track.kind === "audio";
+    const isCustomVideo = isCustomTrack && track.kind === "video";
+
+    if (isCustomAudio) {
+      // Custom audio tracks get their own dedicated audio element
+      selector = `${trackType}-${participantId}`;
+    } else if (isCustomVideo) {
+      // Custom video tracks get their own dedicated video element in a custom container
+      selector = `#video-container-${trackType}-${participantId} video.video-element`;
+      console.log("Custom video selector:", selector);
+    } else if (trackType === "video") {
+      selector = `#video-container-${participantId} video.video-element`;
+    } else {
+      // Regular audio track
+      selector = `audio-${participantId}`;
+    }
 
     // Retrieve the specific media element from the DOM.
     const trackEl =
-      trackType === 'video'
+      trackType === "video" || isCustomVideo
         ? document.querySelector(selector)
         : document.getElementById(selector);
 
@@ -364,41 +467,86 @@ class DailyCallManager {
    * @param {Object} track - The video track object.
    * @param {string} participantId - The ID of the participant.
    */
-  updateVideoUi(track, participantId) {
-    let videoEl = document
-      .getElementById(`video-container-${participantId}`)
-      .querySelector('video.video-element');
+  /**
+   * Shows or hides the video element for a participant, including managing
+   * the visibility of the video based on the track state.
+   * @param {Object} track - The video track object.
+   * @param {string} participantId - The ID of the participant.
+   * @param {string} trackType - The type of track (e.g., 'video', 'customVideo-mytrack').
+   */
+  updateVideoUi(track, participantId, trackType = "video") {
+    // Determine the correct container ID based on track type
+    const isCustomVideo = track.customTrack && track.kind === "video";
+    const containerId = isCustomVideo
+      ? `video-container-${trackType}-${participantId}`
+      : `video-container-${participantId}`;
+
+    const videoContainer = document.getElementById(containerId);
+    if (!videoContainer) {
+      console.error(`Video container ${containerId} not found`);
+      return;
+    }
+
+    const videoEl = videoContainer.querySelector("video.video-element");
+    if (!videoEl) {
+      console.error(`Video element not found in container ${containerId}`);
+      return;
+    }
 
     switch (track.state) {
-      case 'off':
-      case 'interrupted':
-      case 'blocked':
-        videoEl.style.display = 'none'; // Hide video but keep container
+      case "off":
+      case "interrupted":
+      case "blocked":
+        videoEl.style.display = "none"; // Hide video but keep container
         break;
-      case 'playable':
+      case "playable":
       default:
         // Here we handle all other states the same as we handle 'playable'.
         // In your code, you may choose to handle them differently.
-        videoEl.style.display = '';
+        videoEl.style.display = "";
         break;
     }
   }
 
   /**
-   * Cleans up specified media track types (e.g., 'video', 'audio') for a given
-   * participant by stopping the tracks and removing their corresponding
-   * elements from the DOM. This is essential for properly managing resources
-   * when participants leave or change their track states.
-   * @param {Array} trackTypes - An array of track types to destroy, e.g.,
-   * ['video', 'audio'].
+   * Cleans up specified media tracks for a given participant by stopping the
+   * tracks and removing their corresponding elements from the DOM. This is
+   * essential for properly managing resources when participants leave or
+   * change their track states.
+   * @param {Array} trackData - An array of objects with {trackType, trackInfo},
+   * e.g., [{trackType: 'video', trackInfo: {...}}, ...].
    * @param {string} participantId - The ID of the participant.
    */
-  destroyTracks(trackTypes, participantId) {
-    trackTypes.forEach((trackType) => {
-      const elementId = `${trackType}-${participantId}`;
+  destroyTracks(trackData, participantId) {
+    trackData.forEach(({ trackType, trackInfo }) => {
+      let elementId;
+      const isCustomTrack = trackInfo && trackInfo.kind;
+
+      // Determine the correct element ID based on track type
+      if (isCustomTrack && trackInfo.kind === "audio") {
+        // Custom audio tracks have dedicated audio elements
+        elementId = `${trackType}-${participantId}`;
+      } else if (isCustomTrack && trackInfo.kind === "video") {
+        // Custom video tracks have dedicated video containers
+        elementId = `video-container-${trackType}-${participantId}`;
+      } else {
+        // Regular tracks use standard naming
+        elementId = `${trackType}-${participantId}`;
+      }
+
       const element = document.getElementById(elementId);
       if (element) {
-        element.srcObject = null; // Release media resources
+        // For video containers, clean up the video element inside
+        const isCustomVideo = isCustomTrack && trackInfo.kind === "video";
+        if (trackType === "video" || isCustomVideo) {
+          const videoEl = element.querySelector("video.video-element");
+          if (videoEl) {
+            videoEl.srcObject = null;
+          }
+        } else {
+          // For audio elements, clean up directly
+          element.srcObject = null;
+        }
         element.parentNode.removeChild(element); // Remove element from the DOM
       }
     });
@@ -422,19 +570,39 @@ class DailyCallManager {
    * Updates the UI to reflect the current states of the local participant's
    * camera and microphone.
    * @param {string} trackType - The type of track, either 'video' for cameras
-   * or 'audio' for microphones.
+   * or 'audio' for microphones, or custom track types.
    * @param {Object} trackInfo - The track object.
    */
   updateUiForDevicesState(trackType, trackInfo) {
+    const isCustomTrack = trackInfo && trackInfo.kind;
+
     // For video, set the camera state
-    if (trackType === 'video') {
-      document.getElementById('camera-state').textContent = `Camera: ${
-        this.call.localVideo() ? 'On' : 'Off'
+    if (trackType === "video") {
+      document.getElementById("camera-state").textContent = `Camera: ${
+        this.call.localVideo() ? "On" : "Off"
       }`;
-    } else if (trackType === 'audio') {
+    } else if (trackType === "audio") {
       // For audio, set the mic state
-      document.getElementById('mic-state').textContent = `Mic: ${
-        this.call.localAudio() ? 'On' : 'Off'
+      document.getElementById("mic-state").textContent = `Mic: ${
+        this.call.localAudio() ? "On" : "Off"
+      }`;
+    } else if (isCustomTrack && trackInfo.kind === "audio") {
+      // For custom audio tracks, update UI to show custom track name
+      // Extract track name from trackType (format: customAudio-name)
+      const trackName = trackType.replace("customAudio-", "");
+      document.getElementById(
+        "mic-state"
+      ).textContent = `Custom Audio (${trackName}): ${
+        trackInfo.state === "playable" ? "On" : "Off"
+      }`;
+    } else if (isCustomTrack && trackInfo.kind === "video") {
+      // For custom video tracks, update UI to show custom track name
+      // Extract track name from trackType (format: customVideo-name)
+      const trackName = trackType.replace("customVideo-", "");
+      document.getElementById(
+        "camera-state"
+      ).textContent = `Custom Video (${trackName}): ${
+        trackInfo.state === "playable" ? "On" : "Off"
       }`;
     }
   }
@@ -451,17 +619,17 @@ class DailyCallManager {
 
     // Element references for camera and microphone selectors.
     const selectors = {
-      videoinput: document.getElementById('camera-selector'),
-      audioinput: document.getElementById('mic-selector'),
+      videoinput: document.getElementById("camera-selector"),
+      audioinput: document.getElementById("mic-selector"),
     };
 
     // Prepare selectors by clearing existing options and adding a
     // non-selectable prompt.
     Object.values(selectors).forEach((selector) => {
-      selector.innerHTML = '';
+      selector.innerHTML = "";
       const promptOption = new Option(
-        `Select a ${selector.id.includes('camera') ? 'camera' : 'microphone'}`,
-        '',
+        `Select a ${selector.id.includes("camera") ? "camera" : "microphone"}`,
+        "",
         true,
         true
       );
@@ -473,7 +641,7 @@ class DailyCallManager {
     allDevices.forEach((device) => {
       if (device.label && selectors[device.kind]) {
         const isSelected =
-          selectedDevices[device.kind === 'videoinput' ? 'camera' : 'mic']
+          selectedDevices[device.kind === "videoinput" ? "camera" : "mic"]
             .deviceId === device.deviceId;
         const option = new Option(
           device.label,
@@ -487,10 +655,10 @@ class DailyCallManager {
 
     // Listen for user device change requests.
     Object.entries(selectors).forEach(([deviceKind, selector]) => {
-      selector.addEventListener('change', async (e) => {
+      selector.addEventListener("change", async (e) => {
         const deviceId = e.target.value;
         const deviceOptions = {
-          [deviceKind === 'videoinput' ? 'videoDeviceId' : 'audioDeviceId']:
+          [deviceKind === "videoinput" ? "videoDeviceId" : "audioDeviceId"]:
             deviceId,
         };
         await this.call.setInputDevicesAsync(deviceOptions);
@@ -507,7 +675,7 @@ class DailyCallManager {
       this.call.participantCounts().present +
       this.call.participantCounts().hidden;
     document.getElementById(
-      'participant-count'
+      "participant-count"
     ).textContent = `Participants: ${participantCount}`;
   }
 
@@ -518,12 +686,12 @@ class DailyCallManager {
   async leave() {
     try {
       await this.call.leave();
-      document.querySelectorAll('#videos video, audio').forEach((el) => {
+      document.querySelectorAll("#videos video, audio").forEach((el) => {
         el.srcObject = null; // Release media resources
         el.remove(); // Remove the element from the DOM
       });
     } catch (e) {
-      console.error('Leaving failed', e);
+      console.error("Leaving failed", e);
     }
   }
 }
@@ -532,21 +700,19 @@ class DailyCallManager {
  * Main entry point: Setup and event listener bindings after the DOM is fully
  * loaded.
  */
-document.addEventListener('DOMContentLoaded', async () => {
+document.addEventListener("DOMContentLoaded", async () => {
   const dailyCallManager = new DailyCallManager();
 
   // Bind the join call action to the join button.
-  document
-    .getElementById('join-btn')
-    .addEventListener('click', async function () {
-      const roomUrl = document.getElementById('room-url').value.trim();
-      const joinToken =
-        document.getElementById('join-token').value.trim() || null;
-      await dailyCallManager.joinRoom(roomUrl, joinToken);
-    });
+  document.getElementById("join-btn").addEventListener("click", async () => {
+    const roomUrl = document.getElementById("room-url").value.trim();
+    const joinToken =
+      document.getElementById("join-token").value.trim() || null;
+    await dailyCallManager.joinRoom(roomUrl, joinToken);
+  });
 
   // Bind the leave call action to the leave button.
-  document.getElementById('leave-btn').addEventListener('click', function () {
+  document.getElementById("leave-btn").addEventListener("click", () => {
     dailyCallManager.leave();
   });
 });

--- a/samples/client-sdk/getting-started-daily-js/index.js
+++ b/samples/client-sdk/getting-started-daily-js/index.js
@@ -20,11 +20,11 @@ class DailyCallManager {
   async initialize() {
     this.setupEventListeners();
     document
-      .getElementById("toggle-camera")
-      .addEventListener("click", () => this.toggleCamera());
+      .getElementById('toggle-camera')
+      .addEventListener('click', () => this.toggleCamera());
     document
-      .getElementById("toggle-mic")
-      .addEventListener("click", () => this.toggleMicrophone());
+      .getElementById('toggle-mic')
+      .addEventListener('click', () => this.toggleMicrophone());
   }
 
   /**
@@ -32,13 +32,13 @@ class DailyCallManager {
    */
   setupEventListeners() {
     const events = {
-      "active-speaker-change": this.handleActiveSpeakerChange.bind(this),
+      'active-speaker-change': this.handleActiveSpeakerChange.bind(this),
       error: this.handleError.bind(this),
-      "joined-meeting": this.handleJoin.bind(this),
-      "left-meeting": this.handleLeave.bind(this),
-      "participant-joined": this.handleParticipantJoinedOrUpdated.bind(this),
-      "participant-left": this.handleParticipantLeft.bind(this),
-      "participant-updated": this.handleParticipantJoinedOrUpdated.bind(this),
+      'joined-meeting': this.handleJoin.bind(this),
+      'left-meeting': this.handleLeave.bind(this),
+      'participant-joined': this.handleParticipantJoinedOrUpdated.bind(this),
+      'participant-left': this.handleParticipantLeft.bind(this),
+      'participant-updated': this.handleParticipantJoinedOrUpdated.bind(this),
     };
 
     Object.entries(events).forEach(([event, handler]) => {
@@ -63,13 +63,13 @@ class DailyCallManager {
     this.updateAndDisplayParticipantCount();
 
     // Enable the leave button
-    document.getElementById("leave-btn").disabled = false;
+    document.getElementById('leave-btn').disabled = false;
 
     // Enable the toggle camera and mic buttons and selectors
-    document.getElementById("toggle-camera").disabled = false;
-    document.getElementById("toggle-mic").disabled = false;
-    document.getElementById("camera-selector").disabled = false;
-    document.getElementById("mic-selector").disabled = false;
+    document.getElementById('toggle-camera').disabled = false;
+    document.getElementById('toggle-mic').disabled = false;
+    document.getElementById('camera-selector').disabled = false;
+    document.getElementById('mic-selector').disabled = false;
 
     // Set up the camera and mic selectors
     this.setupDeviceSelectors();
@@ -90,36 +90,36 @@ class DailyCallManager {
    * - Removes all video containers
    */
   handleLeave() {
-    console.log("Successfully left the call");
+    console.log('Successfully left the call');
 
     // Update the join and leave button states
-    document.getElementById("leave-btn").disabled = true;
-    document.getElementById("join-btn").disabled = false;
+    document.getElementById('leave-btn').disabled = true;
+    document.getElementById('join-btn').disabled = false;
 
     // Disable the toggle camera and mic buttons
-    document.getElementById("toggle-camera").disabled = true;
-    document.getElementById("toggle-mic").disabled = true;
+    document.getElementById('toggle-camera').disabled = true;
+    document.getElementById('toggle-mic').disabled = true;
 
     // Reset and disable the camera and mic selectors
-    const cameraSelector = document.getElementById("camera-selector");
-    const micSelector = document.getElementById("mic-selector");
+    const cameraSelector = document.getElementById('camera-selector');
+    const micSelector = document.getElementById('mic-selector');
     cameraSelector.selectedIndex = 0;
     micSelector.selectedIndex = 0;
     cameraSelector.disabled = true;
     micSelector.disabled = true;
 
     // Update the call state in the UI
-    document.getElementById("camera-state").textContent = "Camera: Off";
-    document.getElementById("mic-state").textContent = "Mic: Off";
+    document.getElementById('camera-state').textContent = 'Camera: Off';
+    document.getElementById('mic-state').textContent = 'Mic: Off';
     document.getElementById(
-      "participant-count"
+      'participant-count'
     ).textContent = `Participants: 0`;
     document.getElementById(
-      "active-speaker"
+      'active-speaker'
     ).textContent = `Active Speaker: None`;
 
     // Remove all video containers
-    const videosDiv = document.getElementById("videos");
+    const videosDiv = document.getElementById('videos');
     while (videosDiv.firstChild) {
       videosDiv.removeChild(videosDiv.firstChild);
     }
@@ -133,7 +133,7 @@ class DailyCallManager {
    * @param {Object} e - The error event object.
    */
   handleError(e) {
-    console.error("DAILY SENT AN ERROR!", e.error ? e.error : e.errorMsg);
+    console.error('DAILY SENT AN ERROR!', e.error ? e.error : e.errorMsg);
   }
 
   /**
@@ -149,8 +149,8 @@ class DailyCallManager {
     // When a participant leaves, we don't have trackInfo, but we know these are regular tracks
     this.destroyTracks(
       [
-        { trackType: "video", trackInfo: null },
-        { trackType: "audio", trackInfo: null },
+        { trackType: 'video', trackInfo: null },
+        { trackType: 'audio', trackInfo: null },
       ],
       participantId
     );
@@ -202,7 +202,7 @@ class DailyCallManager {
       // If a persistentTrack exists...
       if (trackInfo.persistentTrack) {
         // For custom audio tracks, create a dedicated audio element if it doesn't exist
-        if (trackInfo?.kind === "audio" && !isLocal) {
+        if (trackInfo?.kind === 'audio' && !isLocal) {
           const customAudioId = `${trackType}-${participantId}`;
           if (!document.getElementById(customAudioId)) {
             this.createCustomAudioElement(trackType, participantId);
@@ -210,7 +210,7 @@ class DailyCallManager {
         }
 
         // For custom video tracks, create a dedicated video container if it doesn't exist
-        if (trackInfo?.kind === "video") {
+        if (trackInfo?.kind === 'video') {
           const customVideoId = `video-container-${trackType}-${participantId}`;
           if (!document.getElementById(customVideoId)) {
             this.createCustomVideoContainer(trackType, participantId);
@@ -220,7 +220,7 @@ class DailyCallManager {
         // Check if this is the local participant's audio track.
         // If so, we will skip playing it, as it's already being played.
         // We'll start or update tracks in all other cases.
-        if (!(isLocal && trackType === "audio")) {
+        if (!(isLocal && trackType === 'audio')) {
           this.startOrUpdateTrack(trackType, trackInfo, participantId);
         }
       } else {
@@ -230,7 +230,7 @@ class DailyCallManager {
 
       // Update the video UI based on the track's state
       // For regular and custom video tracks
-      if (trackType === "video" || trackInfo?.kind === "video") {
+      if (trackType === 'video' || trackInfo?.kind === 'video') {
         this.updateVideoUi(trackInfo, participantId, trackType);
       }
 
@@ -248,7 +248,7 @@ class DailyCallManager {
    */
   handleActiveSpeakerChange(event) {
     document.getElementById(
-      "active-speaker"
+      'active-speaker'
     ).textContent = `Active Speaker: ${event.activeSpeaker.peerId}`;
   }
 
@@ -259,7 +259,7 @@ class DailyCallManager {
    */
   async joinRoom(roomUrl, joinToken = null) {
     if (!roomUrl) {
-      console.error("Room URL is required to join a room.");
+      console.error('Room URL is required to join a room.');
       return;
     }
 
@@ -268,18 +268,18 @@ class DailyCallManager {
     const joinOptions = { url: roomUrl };
     if (joinToken) {
       joinOptions.token = joinToken;
-      console.log("Joining with a token.");
+      console.log('Joining with a token.');
     } else {
-      console.log("Joining without a token.");
+      console.log('Joining without a token.');
     }
 
     try {
       // Disable the join button to prevent multiple attempts to join
-      document.getElementById("join-btn").disabled = true;
+      document.getElementById('join-btn').disabled = true;
       // Join the room
       await this.call.join(joinOptions);
     } catch (e) {
-      console.error("Join failed:", e);
+      console.error('Join failed:', e);
     }
   }
 
@@ -294,20 +294,20 @@ class DailyCallManager {
    */
   createVideoContainer(participantId) {
     // Create a video container for the participant
-    const videoContainer = document.createElement("div");
+    const videoContainer = document.createElement('div');
     videoContainer.id = `video-container-${participantId}`;
-    videoContainer.className = "video-container";
-    document.getElementById("videos").appendChild(videoContainer);
+    videoContainer.className = 'video-container';
+    document.getElementById('videos').appendChild(videoContainer);
 
     // Add an overlay to display the participant's session ID
-    const sessionIdOverlay = document.createElement("div");
-    sessionIdOverlay.className = "session-id-overlay";
+    const sessionIdOverlay = document.createElement('div');
+    sessionIdOverlay.className = 'session-id-overlay';
     sessionIdOverlay.textContent = participantId;
     videoContainer.appendChild(sessionIdOverlay);
 
     // Create a video element for the participant
-    const videoEl = document.createElement("video");
-    videoEl.className = "video-element";
+    const videoEl = document.createElement('video');
+    videoEl.className = 'video-element';
     videoContainer.appendChild(videoEl);
   }
 
@@ -322,7 +322,7 @@ class DailyCallManager {
    */
   createAudioElement(participantId) {
     // Create an audio element for the participant
-    const audioEl = document.createElement("audio");
+    const audioEl = document.createElement('audio');
     audioEl.id = `audio-${participantId}`;
     document.body.appendChild(audioEl);
   }
@@ -337,7 +337,7 @@ class DailyCallManager {
    */
   createCustomAudioElement(trackType, participantId) {
     // Create a custom audio element for the participant
-    const audioEl = document.createElement("audio");
+    const audioEl = document.createElement('audio');
     audioEl.id = `${trackType}-${participantId}`;
     audioEl.autoplay = true;
     document.body.appendChild(audioEl);
@@ -353,21 +353,21 @@ class DailyCallManager {
    */
   createCustomVideoContainer(trackType, participantId) {
     // Create a video container for the custom video track
-    const videoContainer = document.createElement("div");
+    const videoContainer = document.createElement('div');
     videoContainer.id = `video-container-${trackType}-${participantId}`;
-    videoContainer.className = "video-container";
-    document.getElementById("videos").appendChild(videoContainer);
+    videoContainer.className = 'video-container';
+    document.getElementById('videos').appendChild(videoContainer);
 
     // Add an overlay to display the track name and participant's session ID
-    const sessionIdOverlay = document.createElement("div");
-    sessionIdOverlay.className = "session-id-overlay";
-    const trackName = trackType.replace("customVideo", "");
+    const sessionIdOverlay = document.createElement('div');
+    sessionIdOverlay.className = 'session-id-overlay';
+    const trackName = trackType.replace('customVideo', '');
     sessionIdOverlay.textContent = `${trackName} (${participantId})`;
     videoContainer.appendChild(sessionIdOverlay);
 
     // Create a video element for the custom video track
-    const videoEl = document.createElement("video");
-    videoEl.className = "video-element";
+    const videoEl = document.createElement('video');
+    videoEl.className = 'video-element';
     videoEl.autoplay = true;
     videoEl.muted = true;
     videoEl.playsInline = true;
@@ -394,14 +394,14 @@ class DailyCallManager {
     // For custom audio and video tracks, we'll use a unique ID based on the track type
     let selector;
     console.log(
-      "Starting or updating track:",
+      'Starting or updating track:',
       trackType,
-      "for participant:",
+      'for participant:',
       participantId,
       track
     );
-    const isCustomAudio = track.kind === "audio";
-    const isCustomVideo = track.kind === "video";
+    const isCustomAudio = track.kind === 'audio';
+    const isCustomVideo = track.kind === 'video';
 
     if (isCustomAudio) {
       // Custom audio tracks get their own dedicated audio element
@@ -409,8 +409,8 @@ class DailyCallManager {
     } else if (isCustomVideo) {
       // Custom video tracks get their own dedicated video element in a custom container
       selector = `#video-container-${trackType}-${participantId} video.video-element`;
-      console.log("Custom video selector:", selector);
-    } else if (trackType === "video") {
+      console.log('Custom video selector:', selector);
+    } else if (trackType === 'video') {
       selector = `#video-container-${participantId} video.video-element`;
     } else {
       // Regular audio track
@@ -419,7 +419,7 @@ class DailyCallManager {
 
     // Retrieve the specific media element from the DOM.
     const trackEl =
-      trackType === "video" || isCustomVideo
+      trackType === 'video' || isCustomVideo
         ? document.querySelector(selector)
         : document.getElementById(selector);
 
@@ -473,9 +473,9 @@ class DailyCallManager {
    * @param {string} participantId - The ID of the participant.
    * @param {string} trackType - The type of track (e.g., 'video', 'customVideo-mytrack').
    */
-  updateVideoUi(track, participantId, trackType = "video") {
+  updateVideoUi(track, participantId, trackType = 'video') {
     // Determine the correct container ID based on track type
-    const isCustomVideo = track.customTrack && track.kind === "video";
+    const isCustomVideo = track.customTrack && track.kind === 'video';
     const containerId = isCustomVideo
       ? `video-container-${trackType}-${participantId}`
       : `video-container-${participantId}`;
@@ -486,23 +486,23 @@ class DailyCallManager {
       return;
     }
 
-    const videoEl = videoContainer.querySelector("video.video-element");
+    const videoEl = videoContainer.querySelector('video.video-element');
     if (!videoEl) {
       console.error(`Video element not found in container ${containerId}`);
       return;
     }
 
     switch (track.state) {
-      case "off":
-      case "interrupted":
-      case "blocked":
-        videoEl.style.display = "none"; // Hide video but keep container
+      case 'off':
+      case 'interrupted':
+      case 'blocked':
+        videoEl.style.display = 'none'; // Hide video but keep container
         break;
-      case "playable":
+      case 'playable':
       default:
         // Here we handle all other states the same as we handle 'playable'.
         // In your code, you may choose to handle them differently.
-        videoEl.style.display = "";
+        videoEl.style.display = '';
         break;
     }
   }
@@ -521,10 +521,10 @@ class DailyCallManager {
       let elementId;
 
       // Determine the correct element ID based on track type
-      if (trackInfo?.kind === "audio") {
+      if (trackInfo?.kind === 'audio') {
         // Custom audio tracks have dedicated audio elements
         elementId = `${trackType}-${participantId}`;
-      } else if (trackInfo?.kind === "video") {
+      } else if (trackInfo?.kind === 'video') {
         // Custom video tracks have dedicated video containers
         elementId = `video-container-${trackType}-${participantId}`;
       } else {
@@ -535,9 +535,9 @@ class DailyCallManager {
       const element = document.getElementById(elementId);
       if (element) {
         // For video containers, clean up the video element inside
-        const isCustomVideo = trackInfo?.kind === "video";
-        if (trackType === "video" || isCustomVideo) {
-          const videoEl = element.querySelector("video.video-element");
+        const isCustomVideo = trackInfo?.kind === 'video';
+        if (trackType === 'video' || isCustomVideo) {
+          const videoEl = element.querySelector('video.video-element');
           if (videoEl) {
             videoEl.srcObject = null;
           }
@@ -573,32 +573,32 @@ class DailyCallManager {
    */
   updateUiForDevicesState(trackType, trackInfo) {
     // For video, set the camera state
-    if (trackType === "video") {
-      document.getElementById("camera-state").textContent = `Camera: ${
-        this.call.localVideo() ? "On" : "Off"
+    if (trackType === 'video') {
+      document.getElementById('camera-state').textContent = `Camera: ${
+        this.call.localVideo() ? 'On' : 'Off'
       }`;
-    } else if (trackType === "audio") {
+    } else if (trackType === 'audio') {
       // For audio, set the mic state
-      document.getElementById("mic-state").textContent = `Mic: ${
-        this.call.localAudio() ? "On" : "Off"
+      document.getElementById('mic-state').textContent = `Mic: ${
+        this.call.localAudio() ? 'On' : 'Off'
       }`;
-    } else if (trackInfo?.kind === "audio") {
+    } else if (trackInfo?.kind === 'audio') {
       // For custom audio tracks, update UI to show custom track name
       // Extract track name from trackType (format: customAudio-name)
-      const trackName = trackType.replace("customAudio-", "");
+      const trackName = trackType.replace('customAudio-', '');
       document.getElementById(
-        "mic-state"
+        'mic-state'
       ).textContent = `Custom Audio (${trackName}): ${
-        trackInfo.state === "playable" ? "On" : "Off"
+        trackInfo.state === 'playable' ? 'On' : 'Off'
       }`;
-    } else if (trackInfo?.kind === "video") {
+    } else if (trackInfo?.kind === 'video') {
       // For custom video tracks, update UI to show custom track name
       // Extract track name from trackType (format: customVideo-name)
-      const trackName = trackType.replace("customVideo-", "");
+      const trackName = trackType.replace('customVideo-', '');
       document.getElementById(
-        "camera-state"
+        'camera-state'
       ).textContent = `Custom Video (${trackName}): ${
-        trackInfo.state === "playable" ? "On" : "Off"
+        trackInfo.state === 'playable' ? 'On' : 'Off'
       }`;
     }
   }
@@ -615,17 +615,17 @@ class DailyCallManager {
 
     // Element references for camera and microphone selectors.
     const selectors = {
-      videoinput: document.getElementById("camera-selector"),
-      audioinput: document.getElementById("mic-selector"),
+      videoinput: document.getElementById('camera-selector'),
+      audioinput: document.getElementById('mic-selector'),
     };
 
     // Prepare selectors by clearing existing options and adding a
     // non-selectable prompt.
     Object.values(selectors).forEach((selector) => {
-      selector.innerHTML = "";
+      selector.innerHTML = '';
       const promptOption = new Option(
-        `Select a ${selector.id.includes("camera") ? "camera" : "microphone"}`,
-        "",
+        `Select a ${selector.id.includes('camera') ? 'camera' : 'microphone'}`,
+        '',
         true,
         true
       );
@@ -637,7 +637,7 @@ class DailyCallManager {
     allDevices.forEach((device) => {
       if (device.label && selectors[device.kind]) {
         const isSelected =
-          selectedDevices[device.kind === "videoinput" ? "camera" : "mic"]
+          selectedDevices[device.kind === 'videoinput' ? 'camera' : 'mic']
             .deviceId === device.deviceId;
         const option = new Option(
           device.label,
@@ -651,10 +651,10 @@ class DailyCallManager {
 
     // Listen for user device change requests.
     Object.entries(selectors).forEach(([deviceKind, selector]) => {
-      selector.addEventListener("change", async (e) => {
+      selector.addEventListener('change', async (e) => {
         const deviceId = e.target.value;
         const deviceOptions = {
-          [deviceKind === "videoinput" ? "videoDeviceId" : "audioDeviceId"]:
+          [deviceKind === 'videoinput' ? 'videoDeviceId' : 'audioDeviceId']:
             deviceId,
         };
         await this.call.setInputDevicesAsync(deviceOptions);
@@ -671,7 +671,7 @@ class DailyCallManager {
       this.call.participantCounts().present +
       this.call.participantCounts().hidden;
     document.getElementById(
-      "participant-count"
+      'participant-count'
     ).textContent = `Participants: ${participantCount}`;
   }
 
@@ -682,12 +682,12 @@ class DailyCallManager {
   async leave() {
     try {
       await this.call.leave();
-      document.querySelectorAll("#videos video, audio").forEach((el) => {
+      document.querySelectorAll('#videos video, audio').forEach((el) => {
         el.srcObject = null; // Release media resources
         el.remove(); // Remove the element from the DOM
       });
     } catch (e) {
-      console.error("Leaving failed", e);
+      console.error('Leaving failed', e);
     }
   }
 }
@@ -696,19 +696,19 @@ class DailyCallManager {
  * Main entry point: Setup and event listener bindings after the DOM is fully
  * loaded.
  */
-document.addEventListener("DOMContentLoaded", async () => {
+document.addEventListener('DOMContentLoaded', async () => {
   const dailyCallManager = new DailyCallManager();
 
   // Bind the join call action to the join button.
-  document.getElementById("join-btn").addEventListener("click", async () => {
-    const roomUrl = document.getElementById("room-url").value.trim();
+  document.getElementById('join-btn').addEventListener('click', async () => {
+    const roomUrl = document.getElementById('room-url').value.trim();
     const joinToken =
-      document.getElementById("join-token").value.trim() || null;
+      document.getElementById('join-token').value.trim() || null;
     await dailyCallManager.joinRoom(roomUrl, joinToken);
   });
 
   // Bind the leave call action to the leave button.
-  document.getElementById("leave-btn").addEventListener("click", () => {
+  document.getElementById('leave-btn').addEventListener('click', () => {
     dailyCallManager.leave();
   });
 });


### PR DESCRIPTION
This PR adds support for subscribing to and displaying custom audio and video tracks in the getting-started-daily-js example.

## Changes
- Modified subscription configuration to subscribe to all tracks including custom tracks
- Added `createCustomAudioElement()` method to create dedicated audio elements for custom audio tracks
- Added `createCustomVideoContainer()` method to create dedicated video containers for custom video tracks
- Updated `handleParticipantJoinedOrUpdated()` to detect and handle custom audio and video tracks using `customTrack.kind` property
- Updated `startOrUpdateTrack()` to play custom audio and video tracks in their dedicated elements
- Updated `updateVideoUi()` to handle visibility for custom video tracks
- Updated `destroyTracks()` to properly clean up custom track elements
- Updated `updateUiForDevicesState()` to display custom track states in the UI
- Refactored track type detection to use `customTrack.kind` field instead of string prefix checks

## Technical Details
- Set `subscribeToTracksAutomatically: false` to enable manual track subscription
- Use `setSubscribedTracks: true` to subscribe to all tracks (regular + custom)
- Custom tracks are identified by checking `trackInfo.customTrack.kind === 'audio'` or `'video'`
- Each custom track gets a unique container with the track name displayed as an overlay